### PR TITLE
feat: add AWS core terraform modules

### DIFF
--- a/infra/terraform/aws-core/.gitignore
+++ b/infra/terraform/aws-core/.gitignore
@@ -1,0 +1,1 @@
+.terraform/

--- a/infra/terraform/aws-core/.terraform.lock.hcl
+++ b/infra/terraform/aws-core/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.1.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:Ka8mEwRFXBabR33iN/WTIEW6RP0z13vFsDlwn11Pf2I=",
+    "zh:14c35d89307988c835a7f8e26f1b83ce771e5f9b41e407f86a644c0152089ac2",
+    "zh:2fb9fe7a8b5afdbd3e903acb6776ef1be3f2e587fb236a8c60f11a9fa165faa8",
+    "zh:35808142ef850c0c60dd93dc06b95c747720ed2c40c89031781165f0c2baa2fc",
+    "zh:35b5dc95bc75f0b3b9c5ce54d4d7600c1ebc96fbb8dfca174536e8bf103c8cdc",
+    "zh:38aa27c6a6c98f1712aa5cc30011884dc4b128b4073a4a27883374bfa3ec9fac",
+    "zh:51fb247e3a2e88f0047cb97bb9df7c228254a3b3021c5534e4563b4007e6f882",
+    "zh:62b981ce491e38d892ba6364d1d0cdaadcee37cc218590e07b310b1dfa34be2d",
+    "zh:bc8e47efc611924a79f947ce072a9ad698f311d4a60d0b4dfff6758c912b7298",
+    "zh:c149508bd131765d1bc085c75a870abb314ff5a6d7f5ac1035a8892d686b6297",
+    "zh:d38d40783503d278b63858978d40e07ac48123a2925e1a6b47e62179c046f87a",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb07f708e3316615f6d218cec198504984c0ce7000b9f1eebff7516e384f4b54",
+  ]
+}

--- a/infra/terraform/aws-core/README.md
+++ b/infra/terraform/aws-core/README.md
@@ -1,0 +1,27 @@
+# AWS Core Infrastructure
+
+This Terraform configuration provisions core AWS components for the SkyRoute platform.
+
+## Modules
+
+- **core-network** – Creates a VPC spanning three availability zones, associated PrivateLink endpoints, and base IAM roles.
+- **eks-cluster** – Provisions an EKS cluster with separate Karpenter-ready spot and on-demand node groups and enables IAM Roles for Service Accounts (IRSA).
+- **global-dns** – Manages Route53 hosted zones for global DNS records.
+
+The root module also configures an Amazon Kinesis Data Stream and an AWS WAF web ACL. Outputs expose values suitable for configuring Argo CD secrets such as the cluster endpoint and certificate authority data.
+
+## Usage
+
+Create a `prod.tfvars` file with values for the variables:
+
+```
+region      = "us-east-1"
+environment = "prod"
+```
+
+Initialize and apply:
+
+```
+terraform init
+terraform apply -var-file=prod.tfvars
+```

--- a/infra/terraform/aws-core/core-network/main.tf
+++ b/infra/terraform/aws-core/core-network/main.tf
@@ -1,0 +1,70 @@
+resource "aws_vpc" "this" {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    Name = "${var.environment}-vpc"
+  }
+}
+
+data "aws_availability_zones" "available" {}
+
+resource "aws_subnet" "private" {
+  count             = 3
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = cidrsubnet(aws_vpc.this.cidr_block, 4, count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  tags = {
+    Name = "${var.environment}-private-${count.index}"
+  }
+}
+
+resource "aws_security_group" "endpoints" {
+  name   = "${var.environment}-endpoints"
+  vpc_id = aws_vpc.this.id
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = [aws_vpc.this.cidr_block]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_vpc_endpoint" "ecr_api" {
+  vpc_id              = aws_vpc.this.id
+  service_name        = "com.amazonaws.${var.region}.ecr.api"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = aws_subnet.private[*].id
+  security_group_ids  = [aws_security_group.endpoints.id]
+  private_dns_enabled = true
+}
+
+resource "aws_vpc_endpoint" "logs" {
+  vpc_id              = aws_vpc.this.id
+  service_name        = "com.amazonaws.${var.region}.logs"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = aws_subnet.private[*].id
+  security_group_ids  = [aws_security_group.endpoints.id]
+  private_dns_enabled = true
+}
+
+resource "aws_iam_role" "privatelink_role" {
+  name               = "${var.environment}-privatelink"
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+}
+
+data "aws_iam_policy_document" "assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}

--- a/infra/terraform/aws-core/core-network/outputs.tf
+++ b/infra/terraform/aws-core/core-network/outputs.tf
@@ -1,0 +1,11 @@
+output "vpc_id" {
+  value = aws_vpc.this.id
+}
+
+output "private_subnet_ids" {
+  value = aws_subnet.private[*].id
+}
+
+output "privatelink_role_arn" {
+  value = aws_iam_role.privatelink_role.arn
+}

--- a/infra/terraform/aws-core/core-network/variables.tf
+++ b/infra/terraform/aws-core/core-network/variables.tf
@@ -1,0 +1,7 @@
+variable "region" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}

--- a/infra/terraform/aws-core/eks-cluster/main.tf
+++ b/infra/terraform/aws-core/eks-cluster/main.tf
@@ -1,0 +1,136 @@
+resource "aws_iam_role" "eks_cluster" {
+  name               = "${var.environment}-eks-cluster"
+  assume_role_policy = data.aws_iam_policy_document.eks_assume.json
+}
+
+data "aws_iam_policy_document" "eks_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["eks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "eks_cluster_policy" {
+  role       = aws_iam_role.eks_cluster.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+}
+
+resource "aws_eks_cluster" "this" {
+  name     = "${var.environment}-cluster"
+  role_arn = aws_iam_role.eks_cluster.arn
+
+  vpc_config {
+    subnet_ids = var.private_subnet_ids
+  }
+}
+
+resource "aws_iam_role" "nodes" {
+  name               = "${var.environment}-eks-nodes"
+  assume_role_policy = data.aws_iam_policy_document.node_assume.json
+}
+
+data "aws_iam_policy_document" "node_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "node_worker" {
+  role       = aws_iam_role.nodes.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "node_cni" {
+  role       = aws_iam_role.nodes.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
+
+resource "aws_iam_role_policy_attachment" "node_registry" {
+  role       = aws_iam_role.nodes.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_eks_node_group" "spot" {
+  cluster_name    = aws_eks_cluster.this.name
+  node_role_arn   = aws_iam_role.nodes.arn
+  node_group_name = "${var.environment}-spot"
+  subnet_ids      = var.private_subnet_ids
+  scaling_config {
+    desired_size = 1
+    max_size     = 3
+    min_size     = 1
+  }
+  instance_types = ["m5.large"]
+  capacity_type  = "SPOT"
+}
+
+resource "aws_eks_node_group" "on_demand" {
+  cluster_name    = aws_eks_cluster.this.name
+  node_role_arn   = aws_iam_role.nodes.arn
+  node_group_name = "${var.environment}-on-demand"
+  subnet_ids      = var.private_subnet_ids
+  scaling_config {
+    desired_size = 1
+    max_size     = 3
+    min_size     = 1
+  }
+  instance_types = ["m5.large"]
+  capacity_type  = "ON_DEMAND"
+}
+
+data "tls_certificate" "this" {
+  url = aws_eks_cluster.this.identity[0].oidc[0].issuer
+}
+
+resource "aws_iam_openid_connect_provider" "this" {
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = [data.tls_certificate.this.certificates[0].sha1_fingerprint]
+  url             = aws_eks_cluster.this.identity[0].oidc[0].issuer
+}
+
+resource "aws_iam_role" "karpenter" {
+  name               = "${var.environment}-karpenter"
+  assume_role_policy = data.aws_iam_policy_document.karpenter_assume.json
+}
+
+data "aws_iam_policy_document" "karpenter_assume" {
+  statement {
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.this.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(aws_iam_openid_connect_provider.this.url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:karpenter:karpenter"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "karpenter_worker" {
+  role       = aws_iam_role.karpenter.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "karpenter_cni" {
+  role       = aws_iam_role.karpenter.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
+
+resource "aws_iam_role_policy_attachment" "karpenter_registry" {
+  role       = aws_iam_role.karpenter.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_iam_role_policy_attachment" "karpenter_ssm" {
+  role       = aws_iam_role.karpenter.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}

--- a/infra/terraform/aws-core/eks-cluster/outputs.tf
+++ b/infra/terraform/aws-core/eks-cluster/outputs.tf
@@ -1,0 +1,15 @@
+output "cluster_name" {
+  value = aws_eks_cluster.this.name
+}
+
+output "cluster_endpoint" {
+  value = aws_eks_cluster.this.endpoint
+}
+
+output "cluster_ca_certificate" {
+  value = aws_eks_cluster.this.certificate_authority[0].data
+}
+
+output "oidc_provider_arn" {
+  value = aws_iam_openid_connect_provider.this.arn
+}

--- a/infra/terraform/aws-core/eks-cluster/variables.tf
+++ b/infra/terraform/aws-core/eks-cluster/variables.tf
@@ -1,0 +1,15 @@
+variable "region" {
+  type = string
+}
+
+variable "environment" {
+  type = string
+}
+
+variable "vpc_id" {
+  type = string
+}
+
+variable "private_subnet_ids" {
+  type = list(string)
+}

--- a/infra/terraform/aws-core/global-dns/main.tf
+++ b/infra/terraform/aws-core/global-dns/main.tf
@@ -1,0 +1,3 @@
+resource "aws_route53_zone" "this" {
+  name = "${var.environment}.example.com"
+}

--- a/infra/terraform/aws-core/global-dns/outputs.tf
+++ b/infra/terraform/aws-core/global-dns/outputs.tf
@@ -1,0 +1,3 @@
+output "zone_id" {
+  value = aws_route53_zone.this.zone_id
+}

--- a/infra/terraform/aws-core/global-dns/variables.tf
+++ b/infra/terraform/aws-core/global-dns/variables.tf
@@ -1,0 +1,3 @@
+variable "environment" {
+  type = string
+}

--- a/infra/terraform/aws-core/main.tf
+++ b/infra/terraform/aws-core/main.tf
@@ -1,0 +1,57 @@
+terraform {
+  required_version = ">= 1.3"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+module "core_network" {
+  source      = "./core-network"
+  region      = var.region
+  environment = var.environment
+}
+
+module "eks_cluster" {
+  source             = "./eks-cluster"
+  region             = var.region
+  environment        = var.environment
+  vpc_id             = module.core_network.vpc_id
+  private_subnet_ids = module.core_network.private_subnet_ids
+}
+
+module "global_dns" {
+  source      = "./global-dns"
+  environment = var.environment
+}
+
+resource "aws_kinesis_stream" "events" {
+  name        = "${var.environment}-events"
+  shard_count = 1
+}
+
+resource "aws_wafv2_web_acl" "main" {
+  name        = "${var.environment}-waf"
+  description = "Global WAF for ${var.environment}"
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    sampled_requests_enabled   = true
+    cloudwatch_metrics_enabled = true
+    metric_name                = "${var.environment}-waf"
+  }
+}

--- a/infra/terraform/aws-core/outputs.tf
+++ b/infra/terraform/aws-core/outputs.tf
@@ -1,0 +1,15 @@
+output "kinesis_stream_name" {
+  value = aws_kinesis_stream.events.name
+}
+
+output "waf_arn" {
+  value = aws_wafv2_web_acl.main.arn
+}
+
+output "argocd_cluster_endpoint" {
+  value = module.eks_cluster.cluster_endpoint
+}
+
+output "argocd_cluster_ca" {
+  value = module.eks_cluster.cluster_ca_certificate
+}

--- a/infra/terraform/aws-core/prod.tfvars
+++ b/infra/terraform/aws-core/prod.tfvars
@@ -1,0 +1,2 @@
+region      = "us-east-1"
+environment = "prod"

--- a/infra/terraform/aws-core/variables.tf
+++ b/infra/terraform/aws-core/variables.tf
@@ -1,0 +1,9 @@
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+variable "environment" {
+  description = "Deployment environment"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- add AWS core Terraform modules for network, EKS, and DNS
- provision Kinesis stream and WAF with outputs for ArgoCD
- document usage with example tfvars apply command

## Testing
- `terraform init`
- `terraform validate`

