### PR TITLE
Add GCP core Terraform modules

### DIFF
--- a/infra/terraform/gcp-core/.terraform.lock.hcl
+++ b/infra/terraform/gcp-core/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.46.0"
+  constraints = ">= 5.0.0"
+  hashes = [
+    "h1:Ab1o3RK6fvjnT12Z9KTcDMnStkw+zuzLfjXDAKKtX0A=",
+    "zh:118169da16cb6febf5ec536a3fad2b2749836c7a0d0a4c80dffde8bf3e13530c",
+    "zh:1f70da65e59aff39c28bad2644a2a59b819a0790d4cacc4aa61d75f9682b7e33",
+    "zh:25cff0664b0dfc7851dcf95a785a623516aad12c04ad4e7f1daca380957ddb60",
+    "zh:48f70209b043243e3a3e001db0c205a9c6e8f8e6a73870d29118ef88007b6ae6",
+    "zh:637249a10189a9c7cbbb6819f35b2e1dfc6edf6b2df574cdef9204d98bdd7faa",
+    "zh:6cf1b7e40e92703af6a454ae788b504f1ba466414e1d79d0ceb851c2f9672d69",
+    "zh:976ae598f8247b88d2ce4e4c6b901cd93674538bd5336be51def5c7ffb00872f",
+    "zh:986e9d8e951f51a7225e9b972bf5b80f19557daa35052bc3740f9c0827e0d3d0",
+    "zh:9d8a1c9d0b4c2073db10082c768af92ffef8ab9b1ed2383c041194de8e143c30",
+    "zh:d55a1f71c502f8672225d8a4aaf257191a89fc2232ede63b79d6f237db6b4802",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fccc1a4dbd98a89c9ce9402aa30418d2afa352286db90d1b1edbbccf48af003b",
+  ]
+}

--- a/infra/terraform/gcp-core/README.md
+++ b/infra/terraform/gcp-core/README.md
@@ -1,0 +1,36 @@
+# GCP Core Infrastructure
+
+This Terraform configuration provisions core GCP infrastructure for the SkyRoute platform, including:
+
+- VPC network with Private Service Connect, IAM bindings, and Workload Identity
+- GKE Autopilot cluster and Pub/Sub topic/subscription for ADS-B events
+- Global Cloud DNS zone
+- Cloud Armor security policy and HTTP health check
+- Service account key output for GitHub secrets
+
+## Prerequisites
+
+- [Terraform](https://www.terraform.io/) >= 1.5
+- Google Cloud project with billing enabled
+- `gcloud` authenticated with permission to manage the project
+
+## Usage
+
+```bash
+# Navigate to the module
+cd infra/terraform/gcp-core
+
+# Initialize providers and modules
+terraform init
+
+# Review the planned changes
+terraform plan -var project_id=YOUR_PROJECT -var domain=example.com
+
+# Apply the configuration
+terraform apply -var project_id=YOUR_PROJECT -var domain=example.com
+
+# Output includes a service account key suitable for storing as a GitHub secret:
+terraform output -raw github_service_account_key > github-key.json
+```
+
+Store `github-key.json` securely and add its contents as a GitHub Actions secret.

--- a/infra/terraform/gcp-core/main.tf
+++ b/infra/terraform/gcp-core/main.tf
@@ -1,0 +1,52 @@
+terraform {
+  required_version = ">= 1.5.0"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+module "core_network" {
+  source          = "./modules/core-network"
+  project_id      = var.project_id
+  region          = var.region
+  network_name    = var.network_name
+  subnetwork_cidr = var.subnetwork_cidr
+}
+
+module "gke_cluster" {
+  source     = "./modules/gke-cluster"
+  project_id = var.project_id
+  region     = var.region
+  network    = module.core_network.network_name
+  subnetwork = module.core_network.subnetwork_name
+}
+
+module "global_dns" {
+  source     = "./modules/global-dns"
+  project_id = var.project_id
+  domain     = var.domain
+}
+
+# Service account for GitHub Actions
+resource "google_service_account" "github" {
+  account_id   = "github-actions"
+  display_name = "GitHub Actions Deploy"
+}
+
+resource "google_service_account_key" "github" {
+  service_account_id = google_service_account.github.name
+}
+
+output "github_service_account_key" {
+  description = "Service account key JSON for GitHub secrets"
+  value       = google_service_account_key.github.private_key
+  sensitive   = true
+}

--- a/infra/terraform/gcp-core/modules/core-network/main.tf
+++ b/infra/terraform/gcp-core/modules/core-network/main.tf
@@ -1,0 +1,54 @@
+resource "google_compute_network" "vpc" {
+  name                    = var.network_name
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "primary" {
+  name                     = "${var.network_name}-subnet"
+  ip_cidr_range            = var.subnetwork_cidr
+  region                   = var.region
+  network                  = google_compute_network.vpc.id
+  private_ip_google_access = true
+}
+
+# Private Service Connect for Google APIs
+resource "google_compute_global_address" "private_service_range" {
+  name          = "private-service-range"
+  purpose       = "VPC_PEERING"
+  address_type  = "INTERNAL"
+  prefix_length = 16
+  network       = google_compute_network.vpc.id
+}
+
+resource "google_service_networking_connection" "private_vpc_connection" {
+  network                 = google_compute_network.vpc.id
+  service                 = "services/servicenetworking.googleapis.com"
+  reserved_peering_ranges = [google_compute_global_address.private_service_range.name]
+}
+
+# Service account for Workload Identity
+resource "google_service_account" "workload" {
+  account_id   = "workload-app"
+  display_name = "Workload Identity Application SA"
+}
+
+resource "google_service_account_iam_member" "workload_identity" {
+  service_account_id = google_service_account.workload.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "serviceAccount:${var.project_id}.svc.id.goog[${var.k8s_namespace}/${var.k8s_service_account}]"
+}
+
+# Example IAM binding for network admin
+resource "google_project_iam_binding" "network_admin" {
+  project = var.project_id
+  role    = "roles/compute.networkAdmin"
+  members = ["serviceAccount:${google_service_account.workload.email}"]
+}
+
+output "network_name" {
+  value = google_compute_network.vpc.name
+}
+
+output "subnetwork_name" {
+  value = google_compute_subnetwork.primary.name
+}

--- a/infra/terraform/gcp-core/modules/core-network/variables.tf
+++ b/infra/terraform/gcp-core/modules/core-network/variables.tf
@@ -1,0 +1,27 @@
+variable "project_id" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "network_name" {
+  type    = string
+  default = "core-network"
+}
+
+variable "subnetwork_cidr" {
+  type    = string
+  default = "10.0.0.0/20"
+}
+
+variable "k8s_namespace" {
+  type    = string
+  default = "default"
+}
+
+variable "k8s_service_account" {
+  type    = string
+  default = "default"
+}

--- a/infra/terraform/gcp-core/modules/gke-cluster/main.tf
+++ b/infra/terraform/gcp-core/modules/gke-cluster/main.tf
@@ -1,0 +1,50 @@
+resource "google_container_cluster" "autopilot" {
+  name       = var.cluster_name
+  location   = var.region
+  network    = var.network
+  subnetwork = var.subnetwork
+
+  enable_autopilot = true
+
+  workload_identity_config {
+    workload_pool = "${var.project_id}.svc.id.goog"
+  }
+}
+
+# Pub/Sub topic and subscription for ADS-B events
+resource "google_pubsub_topic" "adsb" {
+  name = "adsb-events"
+}
+
+resource "google_pubsub_subscription" "adsb" {
+  name  = "adsb-events-sub"
+  topic = google_pubsub_topic.adsb.name
+}
+
+# Cloud Armor security policy
+resource "google_compute_security_policy" "armor" {
+  name = "gke-armor-policy"
+  rule {
+    action   = "allow"
+    priority = 1000
+    match {
+      versioned_expr = "SRC_IPS_V1"
+      config {
+        src_ip_ranges = ["0.0.0.0/0"]
+      }
+    }
+  }
+}
+
+# HTTP health check
+resource "google_compute_health_check" "http" {
+  name = "gke-http-healthcheck"
+  http_health_check {
+    request_path = "/"
+    port         = 80
+  }
+}
+
+output "cluster_name" {
+  value = google_container_cluster.autopilot.name
+}

--- a/infra/terraform/gcp-core/modules/gke-cluster/variables.tf
+++ b/infra/terraform/gcp-core/modules/gke-cluster/variables.tf
@@ -1,0 +1,20 @@
+variable "project_id" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "network" {
+  type = string
+}
+
+variable "subnetwork" {
+  type = string
+}
+
+variable "cluster_name" {
+  type    = string
+  default = "autopilot-cluster"
+}

--- a/infra/terraform/gcp-core/modules/global-dns/main.tf
+++ b/infra/terraform/gcp-core/modules/global-dns/main.tf
@@ -1,0 +1,8 @@
+resource "google_dns_managed_zone" "primary" {
+  name     = "global-zone"
+  dns_name = "${var.domain}."
+}
+
+output "name_servers" {
+  value = google_dns_managed_zone.primary.name_servers
+}

--- a/infra/terraform/gcp-core/modules/global-dns/variables.tf
+++ b/infra/terraform/gcp-core/modules/global-dns/variables.tf
@@ -1,0 +1,7 @@
+variable "project_id" {
+  type = string
+}
+
+variable "domain" {
+  type = string
+}

--- a/infra/terraform/gcp-core/variables.tf
+++ b/infra/terraform/gcp-core/variables.tf
@@ -1,0 +1,27 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "network_name" {
+  description = "Name of the VPC network"
+  type        = string
+  default     = "core-network"
+}
+
+variable "subnetwork_cidr" {
+  description = "CIDR range for the primary subnet"
+  type        = string
+  default     = "10.0.0.0/20"
+}
+
+variable "domain" {
+  description = "Base domain for Cloud DNS"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- scaffold core Terraform infrastructure for GCP
- add modules for networking, GKE Autopilot, and DNS
- document setup and GitHub secret workflow

## Testing
- `terraform fmt -recursive`
- `terraform init -backend=false`
- `terraform validate`
