### PR TITLE
Add Crossplane composites and claims

### DIFF
--- a/infra/crossplane/README.md
+++ b/infra/crossplane/README.md
@@ -1,0 +1,33 @@
+# Crossplane Configuration
+
+This directory hosts Crossplane definitions for multi-cloud resources. Each
+composite resource selects AWS or GCP implementations based on a `region`
+label supplied by claims.
+
+## Installation
+
+Apply the composite resource definitions:
+
+```bash
+kubectl apply -f xrd/CompositeFlightStream.yaml
+kubectl apply -f xrd/CompositeClickHouseCluster.yaml
+kubectl apply -f xrd/CompositeGlobalIngress.yaml
+```
+
+## Example Claims
+
+The claims under `claims/` include a `compositionSelector` that matches the
+`region` label. Provide AWS regions (for example `us-east-1`) to target AWS
+compositions or GCP regions (for example `us-central1`) to target GCP
+compositions.
+
+```bash
+# Flight stream in an AWS region
+kubectl apply -f claims/FlightStreamClaim.yaml
+
+# ClickHouse cluster in a GCP region
+kubectl apply -f claims/CHClusterClaim.yaml
+
+# Global ingress
+kubectl apply -f claims/GlobalIngressClaim.yaml
+```

--- a/infra/crossplane/claims/CHClusterClaim.yaml
+++ b/infra/crossplane/claims/CHClusterClaim.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: ops.skyroute.io/v1alpha1
+kind: CHCluster
+metadata:
+  name: example-chcluster
+  labels:
+    region: us-central1
+spec:
+  compositionSelector:
+    matchLabels:
+      region: us-central1
+  parameters:
+    shardCount: 3
+    region: us-central1

--- a/infra/crossplane/claims/FlightStreamClaim.yaml
+++ b/infra/crossplane/claims/FlightStreamClaim.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: ops.skyroute.io/v1alpha1
+kind: FlightStream
+metadata:
+  name: example-flightstream
+  labels:
+    region: us-east-1
+spec:
+  compositionSelector:
+    matchLabels:
+      region: us-east-1
+  parameters:
+    shardCount: 2
+    region: us-east-1

--- a/infra/crossplane/claims/GlobalIngressClaim.yaml
+++ b/infra/crossplane/claims/GlobalIngressClaim.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: ops.skyroute.io/v1alpha1
+kind: GlobalIngress
+metadata:
+  name: example-global-ingress
+  labels:
+    region: us-east-1
+spec:
+  compositionSelector:
+    matchLabels:
+      region: us-east-1
+  parameters:
+    host: ingress.skyroute.io
+    region: us-east-1

--- a/infra/crossplane/xrd/CompositeClickHouseCluster.yaml
+++ b/infra/crossplane/xrd/CompositeClickHouseCluster.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: compositeclickhouseclusters.ops.skyroute.io
+spec:
+  group: ops.skyroute.io
+  names:
+    kind: CompositeClickHouseCluster
+    plural: compositeclickhouseclusters
+  claimNames:
+    kind: CHCluster
+    plural: chclusters
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  properties:
+                    shardCount:
+                      type: integer
+                      description: Number of shards for the ClickHouse cluster.
+                    region:
+                      type: string
+                      description: Cloud region used to select provider.
+                  required:
+                    - shardCount
+                    - region

--- a/infra/crossplane/xrd/CompositeFlightStream.yaml
+++ b/infra/crossplane/xrd/CompositeFlightStream.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: compositeflightstreams.ops.skyroute.io
+spec:
+  group: ops.skyroute.io
+  names:
+    kind: CompositeFlightStream
+    plural: compositeflightstreams
+  claimNames:
+    kind: FlightStream
+    plural: flightstreams
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  properties:
+                    shardCount:
+                      type: integer
+                      description: Number of shards for the stream.
+                    region:
+                      type: string
+                      description: Cloud region used to select provider.
+                  required:
+                    - shardCount
+                    - region

--- a/infra/crossplane/xrd/CompositeGlobalIngress.yaml
+++ b/infra/crossplane/xrd/CompositeGlobalIngress.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: compositeglobalingresses.ops.skyroute.io
+spec:
+  group: ops.skyroute.io
+  names:
+    kind: CompositeGlobalIngress
+    plural: compositeglobalingresses
+  claimNames:
+    kind: GlobalIngress
+    plural: globalingresses
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              properties:
+                parameters:
+                  type: object
+                  properties:
+                    host:
+                      type: string
+                      description: Hostname for the global ingress.
+                    region:
+                      type: string
+                      description: Cloud region used to select provider.
+                  required:
+                    - host
+                    - region


### PR DESCRIPTION
## Summary
- add composite resource definitions for FlightStream, ClickHouse cluster, and Global ingress
- provide matching claim examples
- document installation and usage

## Testing
- `yamllint infra/crossplane && echo "yamllint: OK"`
