### PR TITLE
Add Grafana dashboards and Prometheus alerts

### DIFF
--- a/charts/prometheus/Chart.yaml
+++ b/charts/prometheus/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: prometheus
+version: 0.1.0
+description: Prometheus configuration with custom alerts
+appVersion: "2.51"

--- a/charts/prometheus/alerts.yaml
+++ b/charts/prometheus/alerts.yaml
@@ -1,0 +1,24 @@
+groups:
+- name: platform-alerts
+  rules:
+  - alert: HighLatency
+    expr: histogram_quantile(0.95, sum(rate(request_duration_seconds_bucket[5m])) by (le)) > 0.5
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "95th percentile latency above 500ms"
+  - alert: IngressUnhealthy
+    expr: sum(rate(nginx_ingress_controller_requests{status!~"2.."}[5m])) / sum(rate(nginx_ingress_controller_requests[5m])) > 0.05
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      summary: "Ingress returning >5% errors"
+  - alert: OPA_Denied
+    expr: sum(rate(gatekeeper_violations_total[5m])) > 0
+    for: 1m
+    labels:
+      severity: critical
+    annotations:
+      summary: "OPA Gatekeeper denied a request"

--- a/charts/prometheus/values.yaml
+++ b/charts/prometheus/values.yaml
@@ -1,0 +1,2 @@
+ruleFiles:
+  - alerts.yaml

--- a/docs/grafana/gatekeeper-audits.json
+++ b/docs/grafana/gatekeeper-audits.json
@@ -1,0 +1,14 @@
+{
+  "title": "Gatekeeper Audits",
+  "schemaVersion": 27,
+  "panels": [
+    {
+      "type": "table",
+      "title": "Policy Violations",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "gatekeeper_violations_total"}
+      ]
+    }
+  ]
+}

--- a/docs/grafana/heatmap.json
+++ b/docs/grafana/heatmap.json
@@ -1,0 +1,14 @@
+{
+  "title": "Flight Telemetry Heatmap",
+  "schemaVersion": 27,
+  "panels": [
+    {
+      "type": "heatmap",
+      "title": "Events Heatmap",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "sum(rate(flight_events_total[5m])) by (region)"}
+      ]
+    }
+  ]
+}

--- a/docs/grafana/latency-red.json
+++ b/docs/grafana/latency-red.json
@@ -1,0 +1,30 @@
+{
+  "title": "Latency RED Metrics",
+  "schemaVersion": 27,
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Request Rate",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "sum(rate(http_requests_total[1m]))"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Error Rate",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "sum(rate(http_requests_total{status!~'2..'}[1m]))"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "95th Percentile Latency",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "histogram_quantile(0.95, sum(rate(request_duration_seconds_bucket[5m])) by (le))"}
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Grafana dashboards for heatmap, latency RED metrics, and Gatekeeper audits
- define Prometheus alerts for latency, ingress health, and OPA denials
- reference alert rule file in Prometheus Helm values

## Testing
- `helm lint charts/prometheus`
- `go test ./...` *(fails: directory prefix . does not contain main module or its selected dependencies)*