### PR TITLE
Add NS1 ingress kill script and Pulsar Terraform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.terraform/

--- a/README.md
+++ b/README.md
@@ -315,6 +315,22 @@ jobs:
 * **Chaos Script** `hack/kill-ingress.sh`: deletes AWS Istio ingress‑gateway; watch NS1 API until weight=0 (≈ 25 s).
 * **Return Path**: Argo Roll‑out recreates pod; NS1 weight gradually restored via Pulsar feedback.
 
+### NS1 API Usage
+
+`hack/kill-ingress.sh` and the accompanying Terraform require access to the NS1
+API.  Export the following variables before invoking the script:
+
+```bash
+export NS1_API_KEY=xxxxxxxx          # NS1 API token
+export NS1_ZONE=example.com          # DNS zone hosting the record
+export NS1_RECORD=ingress.example.com # FQDN of the weighted record
+export NS1_ANSWER_ID=<answer-uuid>   # Answer ID for this cluster
+```
+
+The script deletes Istio ingress pods and polls
+`https://api.nsone.net/v1/zones/${NS1_ZONE}/${NS1_RECORD}` until the selected
+answer's `weight` field reaches `0`.
+
 ---
 
 ## Cost Management

--- a/hack/kill-ingress.sh
+++ b/hack/kill-ingress.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Delete Istio ingress pods and wait for NS1 weight to drop to zero.
+# Required environment variables:
+#   NS1_API_KEY    - NS1 API key for authentication
+#   NS1_ZONE       - DNS zone name (e.g. example.com)
+#   NS1_RECORD     - Fully-qualified record name (e.g. ingress.example.com)
+#   NS1_ANSWER_ID  - NS1 answer ID for this cluster
+# Optional environment variables:
+#   NAMESPACE      - Kubernetes namespace of ingress pods (default: istio-system)
+#   LABEL          - Label selector for ingress pods (default: app=istio-ingressgateway)
+#   POLL_INTERVAL  - Seconds between NS1 API polls (default: 5)
+
+NAMESPACE="${NAMESPACE:-istio-system}"
+LABEL="${LABEL:-app=istio-ingressgateway}"
+POLL_INTERVAL="${POLL_INTERVAL:-5}"
+
+: "${NS1_API_KEY:?NS1_API_KEY environment variable is required}"
+: "${NS1_ZONE:?NS1_ZONE environment variable is required}"
+: "${NS1_RECORD:?NS1_RECORD environment variable is required}"
+: "${NS1_ANSWER_ID:?NS1_ANSWER_ID environment variable is required}"
+
+echo "Deleting Istio ingress pods in namespace ${NAMESPACE} with label ${LABEL}"
+kubectl delete pod -n "${NAMESPACE}" -l "${LABEL}" || true
+
+echo "Polling NS1 for weight of answer ${NS1_ANSWER_ID} in ${NS1_RECORD}.${NS1_ZONE}"
+while true; do
+  weight=$(curl -sf -H "X-NSONE-Key: ${NS1_API_KEY}" \
+    "https://api.nsone.net/v1/zones/${NS1_ZONE}/${NS1_RECORD}" | \
+    jq -r --arg id "${NS1_ANSWER_ID}" '.answers[] | select(.id==$id) | .weight')
+  weight=${weight:-0}
+  echo "Current weight: ${weight}"
+  if [[ "$weight" == "0" ]]; then
+    echo "Weight has dropped to zero"
+    break
+  fi
+  sleep "${POLL_INTERVAL}"
+done

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/ns1-terraform/ns1" {
+  version     = "1.13.4"
+  constraints = "~> 1.13"
+  hashes = [
+    "h1:MF63kfPjs0sUtsIRO0GQMO3xrGzo5/TDICy09PSAJV0=",
+    "zh:0dca14dee33312ec077499850a3d684a2d5d0008c43f9277a7e6f03c27db1287",
+    "zh:0f476eae64cb571ba8fa3b05956fbd04caddc271e4342cface97b2b5a0860bf8",
+    "zh:20f41d829a9f1b4720fdb578ac851f90d247c6c84b2606ecefa26cfc09d762b9",
+    "zh:6579f35cb2475b58a7cf754a693e881ae15010f5c8df0886970e9839a2b745c3",
+    "zh:759a167007dde2336b0a07d3f688b357ffc9af7891f38128cbb12e453a20eb2f",
+    "zh:7945a6fdc7b129a810339da6ebfed3d392de25f6c5cabe698f9eb64d9a5cc161",
+    "zh:8ad09cde8a3940438ca356c877bfc1ce59b6821af465a61cad9c4ede32b60639",
+    "zh:8f692a31d260242a5f371db520cfde4383c9990d1ffa20b4f9174eb45889a413",
+    "zh:97806d598ec12103477124a7d56491e3593dfb3f1cffca6c6ec997466a3a4c2b",
+    "zh:97b67438150e9e68657f9935f8fc61e6b0eaeffd50eea0fcdbfeffe122427e3b",
+    "zh:b498f9d5fb0ab6d196018f356ae35a264c91afb052ae9217cbb6f7dc91032a54",
+    "zh:d95310fe6f2163d95b2d32097755aa5a1359a2db5746d75d92ad97cf0b110096",
+    "zh:e5edfa017c728b3008a6091342969548fd3df1f7bf33adda17fa8f680e7ad2ee",
+    "zh:f37856d9f3f4a6ca0502a3e587a0c2cf6a545c3afc5aabacc3a917ff7120733f",
+  ]
+}

--- a/terraform/pulsar.tf
+++ b/terraform/pulsar.tf
@@ -1,0 +1,90 @@
+terraform {
+  required_providers {
+    ns1 = {
+      source  = "ns1-terraform/ns1"
+      version = "~> 1.13"
+    }
+  }
+}
+
+provider "ns1" {
+  apikey = var.ns1_api_key
+}
+
+variable "ns1_api_key" {
+  description = "API key for NS1"
+  type        = string
+}
+
+variable "zone" {
+  description = "DNS zone that contains the weighted record"
+  type        = string
+}
+
+variable "record" {
+  description = "Fully qualified domain name of the record"
+  type        = string
+}
+
+variable "answers" {
+  description = "Map of endpoint IP addresses to their initial weights"
+  type        = map(number)
+}
+
+variable "pulsar_app_id" {
+  description = "ID of the NS1 Pulsar application"
+  type        = string
+}
+
+variable "pulsar_type_id" {
+  description = "Pulsar job type identifier (e.g. latency, download)"
+  type        = string
+}
+
+resource "ns1_monitoringjob" "ingress" {
+  name      = "ingress-health"
+  job_type  = "tcp"
+  regions   = ["sjc", "lga", "ams"]
+  frequency = 60
+  config = {
+    host = var.record
+    port = "80"
+  }
+}
+
+resource "ns1_pulsarjob" "ingress" {
+  name    = "ingress-performance"
+  app_id  = var.pulsar_app_id
+  type_id = var.pulsar_type_id
+  active  = true
+  config  = {}
+}
+
+resource "ns1_record" "weighted_ingress" {
+  zone   = var.zone
+  domain = var.record
+  type   = "A"
+  ttl    = 60
+
+  dynamic "answers" {
+    for_each = var.answers
+    content {
+      answer = answers.key
+      meta = {
+        weight = tostring(answers.value)
+        up     = "true"
+      }
+    }
+  }
+
+  filters {
+    filter = "weighted_shuffle"
+  }
+
+  filters {
+    filter = "select_first_n"
+    config = {
+      N = "1"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add hack/kill-ingress.sh to delete ingress pods and wait for NS1 weight drain
- document NS1 API variables in README
- include Terraform resources for Pulsar health checks and weighted DNS record

## Testing
- `bash -n hack/kill-ingress.sh`
- `terraform fmt -check`
- `terraform init -backend=false`
- `terraform validate`

