### PR TITLE
Add CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,62 @@
+name: CI/CD
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push images
+        run: |
+          for dir in services/*; do
+            if [ -f "$dir/Dockerfile" ]; then
+              svc=$(basename "$dir")
+              docker buildx build "$dir" --tag ghcr.io/${{ github.repository_owner }}/$svc:${{ github.sha }} --push
+            fi
+          done
+
+      - name: Run unit tests
+        run: |
+          for dir in services/*; do
+            if [ -d "$dir" ]; then
+              if [ -f "$dir/package.json" ]; then
+                npm --prefix "$dir" test
+              elif [ -d "$dir/tests" ]; then
+                pytest "$dir"
+              fi
+            fi
+          done
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Install argocd-image-updater
+        run: |
+          curl -sSL https://github.com/argoproj-labs/argocd-image-updater/releases/latest/download/argocd-image-updater-linux-amd64 -o argocd-image-updater
+          chmod +x argocd-image-updater
+
+      - name: Run argocd-image-updater
+        env:
+          AWS_PROFILE: ${{ secrets.AWS_PROFILE }}
+          GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
+          AZURE_CREDENTIALS: ${{ secrets.AZURE_CREDENTIALS }}
+          DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+          KUBECONFIG: ${{ secrets.KUBECONFIG }}
+        run: ./argocd-image-updater


### PR DESCRIPTION
## Summary
- add CI/CD workflow with build and deploy jobs
- build job pushes service images to GHCR and runs tests
- deploy job invokes argocd-image-updater

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f2982f52c8329a9b8656482c9f03c