### PR TITLE
Add Gatekeeper policies with tests

### DIFF
--- a/policy/constraints/deny-service-without-owner.yaml
+++ b/policy/constraints/deny-service-without-owner.yaml
@@ -1,0 +1,9 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: DenyServiceWithoutOwner
+metadata:
+  name: deny-service-without-owner
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Service"]

--- a/policy/constraints/no-root-containers.yaml
+++ b/policy/constraints/no-root-containers.yaml
@@ -1,0 +1,9 @@
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: NoRootContainers
+metadata:
+  name: no-root-containers
+spec:
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]

--- a/policy/lib/deny-service-without-owner.rego
+++ b/policy/lib/deny-service-without-owner.rego
@@ -1,0 +1,7 @@
+package denyservicewithoutowner
+
+violation contains msg if {
+  input.review.kind.kind == "Service"
+  not input.review.object.metadata.labels.owner
+  msg := sprintf("Service %q is missing required 'owner' label", [input.review.object.metadata.name])
+}

--- a/policy/lib/no-root-containers.rego
+++ b/policy/lib/no-root-containers.rego
@@ -1,0 +1,25 @@
+package norootcontainers
+
+has_run_as_non_root(c) if {
+  c.securityContext.runAsNonRoot == true
+}
+
+has_non_root_user(c) if {
+  c.securityContext.runAsUser > 0
+}
+
+violation contains msg if {
+  input.review.kind.kind == "Pod"
+  container := input.review.object.spec.containers[_]
+  not has_run_as_non_root(container)
+  not has_non_root_user(container)
+  msg := sprintf("container %q must set runAsNonRoot or a non-zero runAsUser", [container.name])
+}
+
+violation contains msg if {
+  input.review.kind.kind == "Pod"
+  container := input.review.object.spec.initContainers[_]
+  not has_run_as_non_root(container)
+  not has_non_root_user(container)
+  msg := sprintf("initContainer %q must set runAsNonRoot or a non-zero runAsUser", [container.name])
+}

--- a/policy/templates/deny-service-without-owner.yaml
+++ b/policy/templates/deny-service-without-owner.yaml
@@ -1,0 +1,19 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: denyservicewithoutowner
+spec:
+  crd:
+    spec:
+      names:
+        kind: DenyServiceWithoutOwner
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package denyservicewithoutowner
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "Service"
+          not input.review.object.metadata.labels.owner
+          msg := sprintf("Service %q is missing required 'owner' label", [input.review.object.metadata.name])
+        }

--- a/policy/templates/no-root-containers.yaml
+++ b/policy/templates/no-root-containers.yaml
@@ -1,0 +1,37 @@
+apiVersion: templates.gatekeeper.sh/v1beta1
+kind: ConstraintTemplate
+metadata:
+  name: norootcontainers
+spec:
+  crd:
+    spec:
+      names:
+        kind: NoRootContainers
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package norootcontainers
+
+        has_run_as_non_root(c) {
+          c.securityContext.runAsNonRoot == true
+        }
+
+        has_non_root_user(c) {
+          c.securityContext.runAsUser > 0
+        }
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "Pod"
+          container := input.review.object.spec.containers[_]
+          not has_run_as_non_root(container)
+          not has_non_root_user(container)
+          msg := sprintf("container %q must set runAsNonRoot or a non-zero runAsUser", [container.name])
+        }
+
+        violation[{"msg": msg}] {
+          input.review.kind.kind == "Pod"
+          container := input.review.object.spec.initContainers[_]
+          not has_run_as_non_root(container)
+          not has_non_root_user(container)
+          msg := sprintf("initContainer %q must set runAsNonRoot or a non-zero runAsUser", [container.name])
+        }

--- a/policy/tests/deny-service-without-owner_test.rego
+++ b/policy/tests/deny-service-without-owner_test.rego
@@ -1,0 +1,15 @@
+package deny_service_without_owner_test
+
+import data.denyservicewithoutowner
+
+test_service_missing_owner_is_denied if {
+  svc := {"kind": "Service", "metadata": {"name": "svc"}}
+  violations := denyservicewithoutowner.violation with input as {"review": {"kind": {"kind": "Service"}, "object": svc}}
+  count(violations) == 1
+}
+
+test_service_with_owner_is_allowed if {
+  svc := {"kind": "Service", "metadata": {"name": "svc", "labels": {"owner": "team"}}}
+  violations := denyservicewithoutowner.violation with input as {"review": {"kind": {"kind": "Service"}, "object": svc}}
+  count(violations) == 0
+}

--- a/policy/tests/no-root-containers_test.rego
+++ b/policy/tests/no-root-containers_test.rego
@@ -1,0 +1,27 @@
+package no_root_containers_test
+
+import data.norootcontainers
+
+bad_pod := {
+  "kind": "Pod",
+  "spec": {
+    "containers": [{"name": "app", "image": "nginx"}]
+  }
+}
+
+good_pod := {
+  "kind": "Pod",
+  "spec": {
+    "containers": [{"name": "app", "image": "nginx", "securityContext": {"runAsNonRoot": true}}]
+  }
+}
+
+test_container_without_security_context_is_denied if {
+  violations := norootcontainers.violation with input as {"review": {"kind": {"kind": "Pod"}, "object": bad_pod}}
+  count(violations) == 1
+}
+
+test_container_with_run_as_non_root_is_allowed if {
+  violations := norootcontainers.violation with input as {"review": {"kind": {"kind": "Pod"}, "object": good_pod}}
+  count(violations) == 0
+}


### PR DESCRIPTION
## Summary
- add deny-service-without-owner Gatekeeper policy and constraint
- add no-root-containers Gatekeeper policy and constraint
- cover policies with conftest unit tests

## Testing
- `conftest verify --policy policy/lib --policy policy/tests`
