### PR TITLE
Add OpenTelemetry collector manifest and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,17 @@ Materialised view in ClickHouse aggregates heat‑map tiles (XYZ) ready for MapL
 * **SLO** example: *P99 ingest latency < 500 ms over 1 day* (RED metrics exported by ingest‑api).
 * **Grafana Dashboards** stored as JSON (`docs/grafana/skyroute_dash.json`).
 
+### Enabling OpenTelemetry sidecar injection
+
+Helm charts opt in to telemetry by annotating pods for the OTel sidecar:
+
+```yaml
+podAnnotations:
+  sidecar.opentelemetry.io/inject: "true"
+```
+
+The injected container reads pipelines from `otel/collector.yaml` and ships traces to Tempo and metrics to Prometheus.
+
 Alerts:
 
 | Alert              | Threshold                 | Action                            |

--- a/k8s/otel-collector.yaml
+++ b/k8s/otel-collector.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: otel-collector-config
+  labels:
+    app: otel-collector
+data:
+  collector.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+          http:
+    
+    exporters:
+      otlp/tempo:
+        endpoint: tempo:4317
+        tls:
+          insecure: true
+      prometheus:
+        endpoint: "0.0.0.0:8889"
+    
+    processors:
+      batch:
+    
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [otlp/tempo]
+        metrics:
+          receivers: [otlp]
+          processors: [batch]
+          exporters: [prometheus]
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: otel-collector
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: otel-collector
+  template:
+    metadata:
+      labels:
+        app: otel-collector
+    spec:
+      containers:
+        - name: otel-collector
+          image: otel/opentelemetry-collector-contrib:0.90.1
+          args: ["--config=/etc/otel/collector.yaml"]
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otel
+      volumes:
+        - name: config
+          configMap:
+            name: otel-collector-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: otel-collector
+spec:
+  selector:
+    app: otel-collector
+  ports:
+    - name: otlp-grpc
+      port: 4317
+    - name: otlp-http
+      port: 4318
+    - name: prometheus
+      port: 8889

--- a/otel/collector.yaml
+++ b/otel/collector.yaml
@@ -1,0 +1,27 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+      http:
+
+exporters:
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+
+processors:
+  batch:
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlp/tempo]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus]


### PR DESCRIPTION
## Summary
- add OpenTelemetry collector config with traces->Tempo and metrics->Prometheus pipelines
- introduce Kubernetes manifest deploying the collector using the config
- document how Helm charts enable OpenTelemetry sidecar injection

## Testing
- `pytest -q`

