### PR TITLE
Add PostgreSQL init scripts and sample data

### DIFF
--- a/postgres/README.md
+++ b/postgres/README.md
@@ -1,0 +1,27 @@
+# PostgreSQL Setup
+
+This directory contains SQL scripts for initializing the database schema and loading sample data for development or testing.
+
+## Initialization
+
+1. Connect to your PostgreSQL database.
+2. Run the initialization script:
+   ```sh
+   psql -U <username> -d <database> -f init.sql
+   ```
+
+## Sample Data
+
+Load sample routes, airports, and NOTAMs data using:
+```sh
+psql -U <username> -d <database> -f sample_data.sql
+```
+
+## Migrations
+
+Place future schema changes in separate SQL files and apply them in order. A common pattern is to prefix migration files with incremental numbers, e.g. `001_add_index.sql`, `002_add_new_table.sql`:
+```sh
+psql -U <username> -d <database> -f migrations/001_add_index.sql
+```
+
+Ensure the `postgis` extension is installed before running migrations that depend on spatial types.

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -1,0 +1,27 @@
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+CREATE TABLE routes (
+    id SERIAL PRIMARY KEY,
+    name TEXT NOT NULL,
+    path GEOGRAPHY(LINESTRING, 4326),
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE airports (
+    id SERIAL PRIMARY KEY,
+    code VARCHAR(10) UNIQUE NOT NULL,
+    name TEXT NOT NULL,
+    location GEOGRAPHY(POINT, 4326),
+    elevation INTEGER,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE notams (
+    id SERIAL PRIMARY KEY,
+    route_id INTEGER REFERENCES routes(id),
+    message TEXT NOT NULL,
+    effective_from TIMESTAMPTZ NOT NULL,
+    effective_to TIMESTAMPTZ NOT NULL,
+    area GEOGRAPHY(POLYGON, 4326),
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);

--- a/postgres/sample_data.sql
+++ b/postgres/sample_data.sql
@@ -1,0 +1,13 @@
+-- Sample data for routes
+INSERT INTO routes (name, path) VALUES
+('Route A', ST_GeogFromText('LINESTRING(-122.389977 37.616299, -118.407997 33.941589)')),
+('Route B', ST_GeogFromText('LINESTRING(-118.407997 33.941589, -115.152333 36.080056)'));
+
+-- Sample data for airports
+INSERT INTO airports (code, name, location, elevation) VALUES
+('SFO', 'San Francisco International Airport', ST_GeogFromText('POINT(-122.389977 37.616299)'), 13),
+('LAX', 'Los Angeles International Airport', ST_GeogFromText('POINT(-118.407997 33.941589)'), 125);
+
+-- Sample data for notams
+INSERT INTO notams (route_id, message, effective_from, effective_to, area) VALUES
+(1, 'Temporary airspace restriction', NOW(), NOW() + INTERVAL '7 days', ST_GeogFromText('POLYGON((-122.5 37.6, -122.3 37.6, -122.3 37.7, -122.5 37.7, -122.5 37.6))'));


### PR DESCRIPTION
## Summary
- add PostGIS-enabled schema with routes, airports, and NOTAMs tables
- provide sample data loader and migration guidance

## Testing
- `apt-get update`
- `apt-get install -y postgresql-client`
- `psql --version`


------
https://chatgpt.com/codex/tasks/task_e_688f297f4de4832983751d5e6bba85d6