### PR TITLE
Add ClickHouse schema and init scripts

### DIFF
--- a/clickhouse/README.md
+++ b/clickhouse/README.md
@@ -1,0 +1,48 @@
+# ClickHouse Schema for Flight Heatmap
+
+This directory contains SQL definitions to store flight telemetry and
+pre-aggregate XYZ tiles for Grafana heatmaps.
+
+## Files
+
+- `flights.sql` – creates the `flights` table using `MergeTree` partitioned
+  by `event_date`.
+- `heatmap_tiles_mv.sql` – creates the `heatmap_tiles` table and accompanying
+  materialized view that turns latitude and longitude into XYZ tiles across
+  zoom levels 0–15.
+- `docker-init.sh` – helper script to load the SQL files when running in a
+  Docker container.
+
+## Docker usage
+
+Mount the SQL files (and optional `docker-init.sh`) into the ClickHouse
+container's `/docker-entrypoint-initdb.d` directory:
+
+```bash
+docker run -v $(pwd)/clickhouse:/docker-entrypoint-initdb.d \
+  clickhouse/clickhouse-server:latest
+```
+
+The official image automatically executes `*.sql` files on first start. If you
+need explicit control, use the provided `docker-init.sh` as an entrypoint.
+
+## Helm integration
+
+Create a ConfigMap that exposes the SQL files and mount it to
+`/docker-entrypoint-initdb.d` in your ClickHouse pod. Example snippet:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clickhouse-init-sql
+  namespace: default
+data:
+  flights.sql: |
+    {{ .Files.Get "clickhouse/flights.sql" | indent 4 }}
+  heatmap_tiles_mv.sql: |
+    {{ .Files.Get "clickhouse/heatmap_tiles_mv.sql" | indent 4 }}
+```
+
+Mount the ConfigMap in your StatefulSet or Pod spec so ClickHouse initializes
+with the required schema.

--- a/clickhouse/docker-init.sh
+++ b/clickhouse/docker-init.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Simple init script to load schema into ClickHouse when the container starts.
+set -e
+clickhouse-client --queries-file /docker-entrypoint-initdb.d/flights.sql
+clickhouse-client --queries-file /docker-entrypoint-initdb.d/heatmap_tiles_mv.sql

--- a/clickhouse/flights.sql
+++ b/clickhouse/flights.sql
@@ -1,0 +1,20 @@
+-- flights.sql
+-- Defines the main table for flight positions.
+-- The table is partitioned by event_date for efficient retention
+-- and uses MergeTree for fast time-series queries.
+
+CREATE TABLE IF NOT EXISTS flights
+(
+    `timestamp` DateTime,
+    `event_date` Date MATERIALIZED toDate(`timestamp`),
+    `flight_id` String,
+    `callsign` String,
+    `lat` Float64,
+    `lon` Float64,
+    `altitude` Float64,
+    `speed` Float64,
+    `heading` Float64
+)
+ENGINE = MergeTree
+PARTITION BY event_date
+ORDER BY (flight_id, timestamp);

--- a/clickhouse/heatmap_tiles_mv.sql
+++ b/clickhouse/heatmap_tiles_mv.sql
@@ -1,0 +1,29 @@
+-- heatmap_tiles_mv.sql
+-- Materialized view generating XYZ tile counts for Grafana heatmaps.
+
+-- Target table to store aggregated tile counts.
+CREATE TABLE IF NOT EXISTS heatmap_tiles
+(
+    `event_date` Date,
+    `z` UInt8,
+    `x` UInt32,
+    `y` UInt32,
+    `hits` UInt32
+)
+ENGINE = SummingMergeTree
+PARTITION BY event_date
+ORDER BY (z, x, y);
+
+-- Materialized view populating the tile table from flight positions.
+CREATE MATERIALIZED VIEW IF NOT EXISTS heatmap_tiles_mv
+TO heatmap_tiles
+AS
+SELECT
+    event_date,
+    z,
+    floor((lon + 180) / 360 * pow(2, z)) AS x,
+    floor((1 - log(tan(radians(lat)) + 1 / cos(radians(lat))) / pi()) / 2 * pow(2, z)) AS y,
+    count() AS hits
+FROM flights
+ARRAY JOIN range(0, 16) AS z
+GROUP BY event_date, z, x, y;


### PR DESCRIPTION
## Summary
- define `flights` MergeTree table partitioned by event_date
- add materialized view for Grafana heatmap tiles
- include Docker init script and Helm ConfigMap instructions

## Testing
- `bash -n clickhouse/docker-init.sh`
- `clickhouse-client --query "SELECT 1"` *(fails: Connection refused)*
