### PR TITLE
feat: add Argo CD root app

### DIFF
--- a/argo/README.md
+++ b/argo/README.md
@@ -1,0 +1,13 @@
+# Argo CD Bootstrap
+
+This directory implements the Argo CD app-of-apps pattern for the SkyRoute Ops platform.
+
+## Bootstrap Steps
+
+1. Deploy Argo CD into the cluster (e.g. via the upstream install manifest).
+2. Apply the root application:
+   ```bash
+   kubectl apply -n argocd -f argo/root.yaml
+   ```
+3. The root app creates child applications for each Helm chart and Cross-Plane claim.
+4. Image updates are handled by `argocd-image-updater` based on annotations on the apps.

--- a/argo/flightstream-claim.yaml
+++ b/argo/flightstream-claim.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: flightstream-claim
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: >-
+      https://github.com/example/SkyRoute-Ops-Multi-Cloud-Zero-Trust-Flight-Tracking-Platform.git
+    targetRevision: HEAD
+    path: infra/crossplane/claims
+    directory:
+      recurse: true
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: crossplane-system
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/argo/ingest-api.yaml
+++ b/argo/ingest-api.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ingest-api
+  namespace: argocd
+  annotations:
+    argocd-image-updater.argoproj.io/image-list: >-
+      ingest-api=ghcr.io/example/ingest-api
+    argocd-image-updater.argoproj.io/update-strategy.ingest-api: semver
+    argocd-image-updater.argoproj.io/write-back-method: git
+spec:
+  project: default
+  source:
+    repoURL: >-
+      https://github.com/example/SkyRoute-Ops-Multi-Cloud-Zero-Trust-Flight-Tracking-Platform.git
+    targetRevision: HEAD
+    path: charts/ingest-api
+    helm:
+      releaseName: ingest-api
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: ingest-api
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/argo/root.yaml
+++ b/argo/root.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: root
+  namespace: argocd
+  annotations:
+    argocd-image-updater.argoproj.io/write-back-method: git
+spec:
+  project: default
+  source:
+    repoURL: >-
+      https://github.com/example/SkyRoute-Ops-Multi-Cloud-Zero-Trust-Flight-Tracking-Platform.git
+    targetRevision: HEAD
+    path: argo
+    directory:
+      recurse: true
+      exclude: '{root.yaml}'
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true


### PR DESCRIPTION
## Summary
- define Argo CD app-of-apps root manifest
- manage ingest-api Helm chart and crossplane claim
- document bootstrap steps

## Testing
- `yamllint argo/root.yaml argo/ingest-api.yaml argo/flightstream-claim.yaml`