### PR TITLE
Add Feast feature store and Kubeflow ETL pipeline

### DIFF
--- a/featurestore/README.md
+++ b/featurestore/README.md
@@ -1,0 +1,31 @@
+# Feature Store
+
+This directory contains a minimal [Feast](https://feast.dev) repository for the SkyRoute platform. It defines
+entities and feature views for ocean buoy telemetry and satellite imagery stored in S3.
+
+## Usage
+
+Initialize the feature store and materialize the latest features:
+
+```bash
+feast apply
+feast materialize-incremental `date +%Y-%m-%d`
+```
+
+### Retrieving Features
+
+Online feature retrieval example:
+
+```python
+from feast import FeatureStore
+
+fs = FeatureStore(repo_path="featurestore")
+features = fs.get_online_features(
+    features=[
+        "buoy_features:wave_height",
+        "buoy_features:water_temp",
+    ],
+    entity_rows=[{"buoy_id": 123}],
+).to_dict()
+print(features)
+```

--- a/featurestore/buoy_features.py
+++ b/featurestore/buoy_features.py
@@ -1,0 +1,49 @@
+"""Feast entity and feature view definitions for buoy and imagery data."""
+from datetime import timedelta
+
+from feast import Entity, FeatureService, FeatureView, Field, FileSource
+from feast.types import Float32, Int64
+
+# Entities
+buoy = Entity(name="buoy_id", join_keys=["buoy_id"], description="Buoy identifier")
+image = Entity(name="image_id", join_keys=["image_id"], description="Imagery tile identifier")
+
+# Data sources pointing at S3 objects containing processed data
+imagery_source = FileSource(
+    path="s3://example-bucket/imagery/imagery.parquet",
+    timestamp_field="event_timestamp",
+)
+
+buoy_source = FileSource(
+    path="s3://example-bucket/buoy/buoy.parquet",
+    timestamp_field="event_timestamp",
+)
+
+# Feature views
+imagery_features = FeatureView(
+    name="imagery_features",
+    entities=[image],
+    ttl=timedelta(days=1),
+    schema=[
+        Field(name="cloud_coverage", dtype=Float32),
+        Field(name="wind_speed", dtype=Float32),
+    ],
+    source=imagery_source,
+)
+
+buoy_features = FeatureView(
+    name="buoy_features",
+    entities=[buoy],
+    ttl=timedelta(days=1),
+    schema=[
+        Field(name="wave_height", dtype=Float32),
+        Field(name="water_temp", dtype=Float32),
+    ],
+    source=buoy_source,
+)
+
+# Feature service to group related features
+ocean_state_fs = FeatureService(
+    name="ocean_state",
+    features=[imagery_features, buoy_features],
+)

--- a/featurestore/feature_store.yaml
+++ b/featurestore/feature_store.yaml
@@ -1,0 +1,8 @@
+project: skyroute
+registry: data/registry.db
+provider: local
+online_store:
+  type: sqlite
+  path: data/online_store.db
+offline_store:
+  type: file

--- a/ml/etl_pipeline.py
+++ b/ml/etl_pipeline.py
@@ -1,0 +1,49 @@
+"""Kubeflow pipeline to ingest S3 imagery and buoy data into Feast."""
+from datetime import datetime
+
+import kfp
+from kfp import dsl
+from kfp.dsl import component
+
+
+@component
+def ingest_imagery(s3_path: str):
+    """Download imagery metadata from S3."""
+    import boto3
+    s3 = boto3.client("s3")
+    bucket, key = s3_path.replace("s3://", "").split("/", 1)
+    s3.download_file(bucket, key, "/tmp/imagery.parquet")
+
+
+@component
+def ingest_buoy(s3_path: str):
+    """Download buoy measurements from S3."""
+    import boto3
+    s3 = boto3.client("s3")
+    bucket, key = s3_path.replace("s3://", "").split("/", 1)
+    s3.download_file(bucket, key, "/tmp/buoy.parquet")
+
+
+@component
+def materialize(repo_path: str = "featurestore"):
+    """Materialize features into Feast."""
+    from feast import FeatureStore
+
+    fs = FeatureStore(repo_path)
+    fs.materialize_incremental(datetime.utcnow())
+
+
+@dsl.pipeline(
+    name="s3-buoy-etl",
+    description="Ingest S3 imagery & buoy data and materialize features into Feast",
+)
+def etl_pipeline(
+    imagery_path: str, buoy_path: str, repo_path: str = "featurestore"
+):
+    img_task = ingest_imagery(imagery_path)
+    buoy_task = ingest_buoy(buoy_path)
+    materialize(repo_path).after(img_task, buoy_task)
+
+
+if __name__ == "__main__":
+    kfp.compiler.Compiler().compile(etl_pipeline, "etl_pipeline.yaml")


### PR DESCRIPTION
## Summary
- add initial Feast repository with buoy and imagery feature views
- create Kubeflow ETL pipeline to ingest S3 imagery and buoy data and materialize features
- document feature retrieval examples

## Testing
- `pre-commit run --files featurestore/feature_store.yaml featurestore/buoy_features.py featurestore/README.md ml/etl_pipeline.py` *(fails: .pre-commit-config.yaml is not a file)*
- `PYTHONPATH=. pytest`

