### PR TITLE
feat: add model serving service with canary rollout

### DIFF
--- a/charts/model-serving/Chart.yaml
+++ b/charts/model-serving/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: model-serving
+description: Helm chart for model serving service with Argo Rollout canary
+
+type: application
+version: 0.1.0
+appVersion: "1.0"

--- a/charts/model-serving/templates/_helpers.tpl
+++ b/charts/model-serving/templates/_helpers.tpl
@@ -1,0 +1,39 @@
+{{/* Expand the name of the chart */}}
+{{- define "model-serving.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Create a default fully qualified app name */}}
+{{- define "model-serving.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Common labels */}}
+{{- define "model-serving.labels" -}}
+helm.sh/chart: {{ include "model-serving.chart" . }}
+{{ include "model-serving.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/* Chart name and version */}}
+{{- define "model-serving.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/* Selector labels */}}
+{{- define "model-serving.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "model-serving.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/model-serving/templates/analysis.yaml
+++ b/charts/model-serving/templates/analysis.yaml
@@ -1,0 +1,15 @@
+apiVersion: argoproj.io/v1alpha1
+kind: AnalysisTemplate
+metadata:
+  name: model-serving-latency
+spec:
+  metrics:
+    - name: p99-latency
+      interval: 1m
+      successCondition: result < 0.5
+      failureLimit: 1
+      provider:
+        prometheus:
+          address: {{ .Values.analysis.prometheusAddress }}
+          query: |
+            histogram_quantile(0.99, sum(rate(request_duration_seconds_bucket{app="{{ include "model-serving.name" . }}"}[5m])) by (le))

--- a/charts/model-serving/templates/rollout.yaml
+++ b/charts/model-serving/templates/rollout.yaml
@@ -1,0 +1,38 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+metadata:
+  name: {{ include "model-serving.fullname" . }}
+  labels:
+    {{- include "model-serving.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      {{- include "model-serving.selectorLabels" . | nindent 6 }}
+  strategy:
+    canary:
+      canaryService: {{ include "model-serving.fullname" . }}-canary
+      stableService: {{ include "model-serving.fullname" . }}-stable
+      steps:
+        - setWeight: 20
+        - pause: { duration: 30s }
+        - analysis:
+            templates:
+              - templateName: model-serving-latency
+        - setWeight: 50
+        - pause: { duration: 30s }
+        - analysis:
+            templates:
+              - templateName: model-serving-latency
+  template:
+    metadata:
+      labels:
+        {{- include "model-serving.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: model-serving
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 8080

--- a/charts/model-serving/templates/service-canary.yaml
+++ b/charts/model-serving/templates/service-canary.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "model-serving.fullname" . }}-canary
+  labels:
+    {{- include "model-serving.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "model-serving.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8080

--- a/charts/model-serving/templates/service-stable.yaml
+++ b/charts/model-serving/templates/service-stable.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "model-serving.fullname" . }}-stable
+  labels:
+    {{- include "model-serving.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "model-serving.selectorLabels" . | nindent 4 }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 8080

--- a/charts/model-serving/templates/tests/test-connection.yaml
+++ b/charts/model-serving/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "model-serving.fullname" . }}-test-connection"
+  labels:
+    {{- include "model-serving.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "model-serving.fullname" . }}-stable:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/model-serving/values.yaml
+++ b/charts/model-serving/values.yaml
@@ -1,0 +1,9 @@
+replicaCount: 1
+image:
+  repository: myorg/model-serving
+  tag: "1.0.0"
+  pullPolicy: IfNotPresent
+service:
+  port: 80
+analysis:
+  prometheusAddress: http://prometheus-server.default.svc.cluster.local

--- a/charts/prometheus/alerts.yaml
+++ b/charts/prometheus/alerts.yaml
@@ -22,3 +22,10 @@ groups:
       severity: critical
     annotations:
       summary: "OPA Gatekeeper denied a request"
+  - alert: ModelServingCanaryLatencyHigh
+    expr: histogram_quantile(0.99, sum(rate(request_duration_seconds_bucket{app="model-serving",rollout="canary"}[5m])) by (le)) > 0.5
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Model serving canary P99 latency above 500ms"

--- a/services/model-serving/Dockerfile
+++ b/services/model-serving/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY app.py .
+CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/services/model-serving/app.py
+++ b/services/model-serving/app.py
@@ -1,0 +1,24 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List
+
+app = FastAPI(title="Model Serving Service")
+
+
+class PredictRequest(BaseModel):
+    instances: List[float]
+
+
+class PredictResponse(BaseModel):
+    predictions: List[float]
+
+
+@app.post("/predict", response_model=PredictResponse)
+async def predict(request: PredictRequest) -> PredictResponse:
+    outputs = [x * 2 for x in request.instances]
+    return PredictResponse(predictions=outputs)
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}

--- a/services/model-serving/inferenceservice.yaml
+++ b/services/model-serving/inferenceservice.yaml
@@ -1,0 +1,12 @@
+apiVersion: serving.kserve.io/v1beta1
+kind: InferenceService
+metadata:
+  name: model-serving
+spec:
+  predictor:
+    custom:
+      container:
+        image: model-serving:latest
+        name: model-serving
+        ports:
+          - containerPort: 8080

--- a/services/model-serving/requirements.txt
+++ b/services/model-serving/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/services/model-serving/test_model_serving.py
+++ b/services/model-serving/test_model_serving.py
@@ -1,0 +1,22 @@
+import pathlib
+import sys
+
+from fastapi.testclient import TestClient
+
+sys.path.append(str(pathlib.Path(__file__).parent))
+
+import app
+
+client = TestClient(app.app)
+
+
+def test_predict():
+    response = client.post("/predict", json={"instances": [1, 2]})
+    assert response.status_code == 200
+    assert response.json()["predictions"] == [2, 4]
+
+
+def test_health():
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"


### PR DESCRIPTION
## Summary
- add model-serving FastAPI service with KServe manifest
- provide Helm chart using Argo Rollouts for canary deployments
- monitor canary P99 latency via Prometheus alert

## Testing
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_688f32e2f3d88329bdedea2d3769c734