### PR TITLE
feat: add edge lambda for mode-s parsing

### DIFF
--- a/infra/terraform/aws-core/edge-lambda.tf
+++ b/infra/terraform/aws-core/edge-lambda.tf
@@ -1,0 +1,45 @@
+resource "aws_iam_role" "edge_lambda" {
+  name = "${var.environment}-edge-lambda-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = ["lambda.amazonaws.com", "edgelambda.amazonaws.com"]
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "edge_lambda_basic" {
+  role       = aws_iam_role.edge_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "edge_lambda_kinesis" {
+  role       = aws_iam_role.edge_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonKinesisFullAccess"
+}
+
+resource "aws_lambda_function" "edge" {
+  function_name    = "${var.environment}-edge-lambda"
+  role             = aws_iam_role.edge_lambda.arn
+  handler          = "handler.handle"
+  runtime          = "python3.11"
+  filename         = "${path.module}/../../../services/edge-lambda/handler.zip"
+  source_code_hash = filebase64sha256("${path.module}/../../../services/edge-lambda/handler.zip")
+  publish          = true
+
+  environment {
+    variables = {
+      TARGET_CLOUD   = var.edge_lambda_provider
+      KINESIS_STREAM = aws_kinesis_stream.events.name
+      PUBSUB_TOPIC   = var.edge_lambda_pubsub_topic
+    }
+  }
+}
+

--- a/infra/terraform/aws-core/variables.tf
+++ b/infra/terraform/aws-core/variables.tf
@@ -7,3 +7,16 @@ variable "environment" {
   description = "Deployment environment"
   type        = string
 }
+
+variable "edge_lambda_provider" {
+  description = "Target cloud for edge lambda (aws or gcp)"
+  type        = string
+  default     = "aws"
+}
+
+variable "edge_lambda_pubsub_topic" {
+  description = "Pub/Sub topic when edge lambda targets GCP"
+  type        = string
+  default     = ""
+}
+

--- a/services/edge-lambda/README.md
+++ b/services/edge-lambda/README.md
@@ -1,0 +1,38 @@
+# Edge Lambda
+
+Lambda@Edge function that parses UDP Mode-S messages and forwards them to a
+streaming service. Depending on `TARGET_CLOUD` it will publish to either an AWS
+Kinesis stream or a Google Cloud Pub/Sub topic.
+
+## Environment Variables
+
+| Name | Description |
+|------|-------------|
+| `TARGET_CLOUD` | `aws` or `gcp` to select the destination. Defaults to `aws`. |
+| `KINESIS_STREAM` | Name of the Kinesis stream to publish to when `TARGET_CLOUD=aws`. |
+| `PUBSUB_TOPIC` | Full Pub/Sub topic path when `TARGET_CLOUD=gcp` (e.g. `projects/my-proj/topics/mode-s`). |
+
+## Packaging
+
+The function expects to be deployed as a zip file named `handler.zip` containing
+`handler.py` and its dependencies. A simple packaging command:
+
+```bash
+cd services/edge-lambda
+zip handler.zip handler.py
+```
+
+## Deployment with Terraform
+
+A Terraform module is provided under `infra/terraform/aws-core/edge-lambda.tf`.
+After packaging the function, deploy with:
+
+```bash
+cd infra/terraform/aws-core
+terraform init -backend=false
+terraform apply -var="environment=dev" -var="region=us-east-1"
+```
+
+Adjust variables as needed. The Lambda function is created with permissions to
+write to the Kinesis stream defined in the same Terraform stack.
+

--- a/services/edge-lambda/handler.py
+++ b/services/edge-lambda/handler.py
@@ -1,0 +1,78 @@
+import base64
+import json
+import os
+from typing import Any, Dict, List
+
+try:
+    import boto3  # type: ignore
+except Exception:  # pragma: no cover
+    boto3 = None
+
+try:
+    from google.cloud import pubsub_v1  # type: ignore
+except Exception:  # pragma: no cover
+    pubsub_v1 = None
+
+_kinesis_client = None
+_pubsub_client = None
+
+def parse_mode_s(raw: str) -> Dict[str, Any]:
+    """Very small Mode-S frame parser returning basic information."""
+    frame = raw.strip().upper()
+    if len(frame) < 2:
+        return {"raw": frame}
+    try:
+        first_byte = int(frame[0:2], 16)
+        df = first_byte >> 3  # Downlink Format is first 5 bits
+    except ValueError:
+        df = None
+    return {"raw": frame, "df": df}
+
+def _send_kinesis(stream: str, payload: Dict[str, Any]) -> None:
+    global _kinesis_client
+    if boto3 is None:
+        raise RuntimeError("boto3 not available")
+    if _kinesis_client is None:
+        _kinesis_client = boto3.client("kinesis")
+    _kinesis_client.put_record(
+        StreamName=stream,
+        Data=json.dumps(payload).encode("utf-8"),
+        PartitionKey="mode-s",
+    )
+
+def _send_pubsub(topic: str, payload: Dict[str, Any]) -> None:
+    global _pubsub_client
+    if pubsub_v1 is None:
+        raise RuntimeError("google-cloud-pubsub not available")
+    if _pubsub_client is None:
+        _pubsub_client = pubsub_v1.PublisherClient()
+    _pubsub_client.publish(topic, json.dumps(payload).encode("utf-8"))
+
+def handle(event: Dict[str, Any], context: Any) -> Dict[str, Any]:
+    """Lambda entrypoint: parse Mode-S messages and forward to stream."""
+    provider = os.getenv("TARGET_CLOUD", "aws").lower()
+    stream = os.getenv("KINESIS_STREAM", "")
+    topic = os.getenv("PUBSUB_TOPIC", "")
+
+    raw_messages: List[str] = []
+    if isinstance(event, dict) and "messages" in event:
+        raw_messages = event["messages"]
+    elif isinstance(event, dict) and "Records" in event:
+        for record in event["Records"]:
+            data = record.get("kinesis", {}).get("data")
+            if data:
+                raw_messages.append(base64.b64decode(data).decode("utf-8"))
+    elif isinstance(event, dict) and "body" in event:
+        raw_messages = [event["body"]]
+
+    results = []
+    for raw in raw_messages:
+        parsed = parse_mode_s(raw)
+        if provider == "aws" and stream:
+            _send_kinesis(stream, parsed)
+        elif provider == "gcp" and topic:
+            _send_pubsub(topic, parsed)
+        results.append(parsed)
+
+    return {"processed": len(results)}
+


### PR DESCRIPTION
## Summary
- add Lambda handler to parse UDP Mode-S messages and forward to Kinesis or Pub/Sub
- document edge lambda deployment and configuration
- add Terraform module to deploy Lambda@Edge

## Testing
- `python -m py_compile services/edge-lambda/handler.py`
- `terraform fmt`
- `terraform init -backend=false`
- `terraform validate`


------
https://chatgpt.com/codex/tasks/task_e_688f38aa10808329b3f99dd4b6910e6c