### PR TITLE
Add provider-specific Crossplane compositions

### DIFF
--- a/infra/crossplane/README.md
+++ b/infra/crossplane/README.md
@@ -6,12 +6,21 @@ label supplied by claims.
 
 ## Installation
 
-Apply the composite resource definitions:
+Install the composite resource definitions followed by provider-specific compositions:
 
 ```bash
+# XRDs
 kubectl apply -f xrd/CompositeFlightStream.yaml
 kubectl apply -f xrd/CompositeClickHouseCluster.yaml
 kubectl apply -f xrd/CompositeGlobalIngress.yaml
+
+# Compositions
+kubectl apply -f compositions/flightstream-aws.yaml
+kubectl apply -f compositions/flightstream-gcp.yaml
+kubectl apply -f compositions/clickhouse-aws.yaml
+kubectl apply -f compositions/clickhouse-gcp.yaml
+kubectl apply -f compositions/globalingress-aws.yaml
+kubectl apply -f compositions/globalingress-gcp.yaml
 ```
 
 ## Example Claims

--- a/infra/crossplane/compositions/clickhouse-aws.yaml
+++ b/infra/crossplane/compositions/clickhouse-aws.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: clickhouse-aws
+  labels:
+    region: us-east-1
+spec:
+  compositeTypeRef:
+    apiVersion: ops.skyroute.io/v1alpha1
+    kind: CompositeClickHouseCluster
+  resources:
+    - name: instance
+      base:
+        apiVersion: ec2.aws.crossplane.io/v1beta1
+        kind: Instance
+        spec:
+          forProvider:
+            region: us-east-1
+            instanceType: t3.small
+          providerConfigRef:
+            name: aws
+      patches:
+        - fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+        - fromFieldPath: spec.parameters.shardCount
+          toFieldPath: metadata.labels.shardCount

--- a/infra/crossplane/compositions/clickhouse-gcp.yaml
+++ b/infra/crossplane/compositions/clickhouse-gcp.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: clickhouse-gcp
+  labels:
+    region: us-central1
+spec:
+  compositeTypeRef:
+    apiVersion: ops.skyroute.io/v1alpha1
+    kind: CompositeClickHouseCluster
+  resources:
+    - name: instance
+      base:
+        apiVersion: compute.gcp.upbound.io/v1beta1
+        kind: Instance
+        spec:
+          forProvider:
+            zone: us-central1-a
+          providerConfigRef:
+            name: gcp
+      patches:
+        - fromFieldPath: spec.parameters.shardCount
+          toFieldPath: metadata.labels.shardCount
+        - fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.zone
+          transforms:
+            - type: string
+              string:
+                fmt: "%s-a"

--- a/infra/crossplane/compositions/flightstream-aws.yaml
+++ b/infra/crossplane/compositions/flightstream-aws.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: flightstream-aws
+  labels:
+    region: us-east-1
+spec:
+  compositeTypeRef:
+    apiVersion: ops.skyroute.io/v1alpha1
+    kind: CompositeFlightStream
+  resources:
+    - name: stream
+      base:
+        apiVersion: kinesis.aws.crossplane.io/v1alpha1
+        kind: Stream
+        spec:
+          forProvider:
+            region: us-east-1
+            shardCount: 1
+          providerConfigRef:
+            name: aws
+      patches:
+        - fromFieldPath: spec.parameters.shardCount
+          toFieldPath: spec.forProvider.shardCount
+        - fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region

--- a/infra/crossplane/compositions/flightstream-gcp.yaml
+++ b/infra/crossplane/compositions/flightstream-gcp.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: flightstream-gcp
+  labels:
+    region: us-central1
+spec:
+  compositeTypeRef:
+    apiVersion: ops.skyroute.io/v1alpha1
+    kind: CompositeFlightStream
+  resources:
+    - name: topic
+      base:
+        apiVersion: pubsub.gcp.upbound.io/v1beta1
+        kind: Topic
+        spec:
+          forProvider:
+            labels:
+              region: us-central1
+          providerConfigRef:
+            name: gcp
+      patches:
+        - fromFieldPath: spec.parameters.shardCount
+          toFieldPath: metadata.labels.shardCount
+        - fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.labels.region

--- a/infra/crossplane/compositions/globalingress-aws.yaml
+++ b/infra/crossplane/compositions/globalingress-aws.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: globalingress-aws
+  labels:
+    region: us-east-1
+spec:
+  compositeTypeRef:
+    apiVersion: ops.skyroute.io/v1alpha1
+    kind: CompositeGlobalIngress
+  resources:
+    - name: alb
+      base:
+        apiVersion: alb.aws.crossplane.io/v1alpha1
+        kind: LoadBalancer
+        spec:
+          forProvider:
+            region: us-east-1
+          providerConfigRef:
+            name: aws
+      patches:
+        - fromFieldPath: spec.parameters.host
+          toFieldPath: metadata.labels.host
+        - fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region

--- a/infra/crossplane/compositions/globalingress-gcp.yaml
+++ b/infra/crossplane/compositions/globalingress-gcp.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: globalingress-gcp
+  labels:
+    region: us-central1
+spec:
+  compositeTypeRef:
+    apiVersion: ops.skyroute.io/v1alpha1
+    kind: CompositeGlobalIngress
+  resources:
+    - name: forwardingrule
+      base:
+        apiVersion: compute.gcp.upbound.io/v1beta1
+        kind: ForwardingRule
+        spec:
+          forProvider:
+            region: us-central1
+          providerConfigRef:
+            name: gcp
+      patches:
+        - fromFieldPath: spec.parameters.host
+          toFieldPath: metadata.labels.host
+        - fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region


### PR DESCRIPTION
## Summary
- add AWS and GCP compositions for FlightStream, ClickHouse cluster, and GlobalIngress with region labels and claim parameter patches
- document installation order and sample apply commands

## Testing
- `yamllint infra/crossplane/compositions/*.yaml`