### PR TITLE
Add model monitoring job and Helm chart

### DIFF
--- a/charts/model-monitor/Chart.yaml
+++ b/charts/model-monitor/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: model-monitor
+description: A Helm chart for the model monitoring job
+type: application
+version: 0.1.0
+appVersion: "1.0.0"

--- a/charts/model-monitor/templates/NOTES.txt
+++ b/charts/model-monitor/templates/NOTES.txt
@@ -1,0 +1,1 @@
+The model-monitor CronJob exposes Prometheus metrics on {{ .Values.service.port }}.

--- a/charts/model-monitor/templates/_helpers.tpl
+++ b/charts/model-monitor/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "model-monitor.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "model-monitor.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "model-monitor.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "model-monitor.labels" -}}
+helm.sh/chart: {{ include "model-monitor.chart" . }}
+{{ include "model-monitor.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "model-monitor.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "model-monitor.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/model-monitor/templates/cronjob.yaml
+++ b/charts/model-monitor/templates/cronjob.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "model-monitor.fullname" . }}
+  labels:
+    {{- include "model-monitor.labels" . | nindent 4 }}
+spec:
+  schedule: {{ .Values.schedule | quote }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            {{- include "model-monitor.selectorLabels" . | nindent 12 }}
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: model-monitor
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              env:
+                - name: BASELINE_PATH
+                  value: {{ .Values.config.baselinePath | quote }}
+                - name: RECENT_PATH
+                  value: {{ .Values.config.recentPath | quote }}
+              ports:
+                - name: metrics
+                  containerPort: {{ .Values.service.port }}

--- a/charts/model-monitor/templates/service.yaml
+++ b/charts/model-monitor/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "model-monitor.fullname" . }}
+  labels:
+    {{- include "model-monitor.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: metrics
+      port: {{ .Values.service.port }}
+      targetPort: metrics
+  selector:
+    {{- include "model-monitor.selectorLabels" . | nindent 4 }}

--- a/charts/model-monitor/templates/servicemonitor.yaml
+++ b/charts/model-monitor/templates/servicemonitor.yaml
@@ -1,0 +1,13 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "model-monitor.fullname" . }}
+  labels:
+    {{- include "model-monitor.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "model-monitor.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: /metrics

--- a/charts/model-monitor/values.yaml
+++ b/charts/model-monitor/values.yaml
@@ -1,0 +1,14 @@
+# Default values for model-monitor.
+image:
+  repository: myorg/model-monitor
+  pullPolicy: IfNotPresent
+  tag: "1.0.0"
+
+schedule: "*/5 * * * *"
+
+service:
+  port: 8000
+
+config:
+  baselinePath: /data/baseline.csv
+  recentPath: /data/recent.csv

--- a/docs/grafana/drift.json
+++ b/docs/grafana/drift.json
@@ -1,0 +1,22 @@
+{
+  "title": "Model Drift Metrics",
+  "schemaVersion": 27,
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Drifted Columns Share",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "model_drift_share"}
+      ]
+    },
+    {
+      "type": "graph",
+      "title": "Drift Detected",
+      "datasource": "Prometheus",
+      "targets": [
+        {"expr": "model_drift_detected"}
+      ]
+    }
+  ]
+}

--- a/services/model-monitor/Dockerfile
+++ b/services/model-monitor/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+ENV METRICS_PORT=8000
+CMD ["python", "main.py"]

--- a/services/model-monitor/main.py
+++ b/services/model-monitor/main.py
@@ -1,0 +1,38 @@
+import os
+import time
+import pandas as pd
+from prometheus_client import Gauge, start_http_server
+from evidently.report import Report
+from evidently.metric_preset import DataDriftPreset
+
+METRICS_PORT = int(os.getenv("METRICS_PORT", "8000"))
+BASELINE_PATH = os.getenv("BASELINE_PATH", "/data/baseline.csv")
+RECENT_PATH = os.getenv("RECENT_PATH", "/data/recent.csv")
+SLEEP_SECONDS = int(os.getenv("SLEEP_SECONDS", "30"))
+
+# Prometheus metrics
+DRIFT_SHARE = Gauge("model_drift_share", "Share of features with detected drift")
+DRIFT_DETECTED = Gauge("model_drift_detected", "Whether dataset drift was detected (1=yes)")
+
+
+def compute_drift():
+    """Run Evidently data drift report and update Prometheus metrics."""
+    baseline = pd.read_csv(BASELINE_PATH)
+    recent = pd.read_csv(RECENT_PATH)
+
+    report = Report(metrics=[DataDriftPreset()])
+    report.run(reference_data=baseline, current_data=recent)
+    summary = report.as_dict()["metrics"][0]["result"]["dataset_drift"]
+
+    DRIFT_SHARE.set(summary["share_drifted_columns"])
+    DRIFT_DETECTED.set(1 if summary["dataset_drift"] else 0)
+
+
+def main() -> None:
+    start_http_server(METRICS_PORT)
+    compute_drift()
+    time.sleep(SLEEP_SECONDS)
+
+
+if __name__ == "__main__":
+    main()

--- a/services/model-monitor/requirements.txt
+++ b/services/model-monitor/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+prometheus-client
+evidently


### PR DESCRIPTION
## Summary
- add Evidently-based model monitoring job that exposes drift metrics for Prometheus
- helm chart to schedule job and provide metrics ServiceMonitor
- dashboard to visualize drift indicators in Grafana

## Testing
- `PYTHONPATH=. pytest`
