### PR TITLE
Add Tempo Helm chart and integrate with collector

### DIFF
--- a/charts/tempo/Chart.yaml
+++ b/charts/tempo/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: tempo
+description: Grafana Tempo deployment via dependency chart
+version: 0.1.0
+appVersion: "2.8.1"
+dependencies:
+  - name: tempo
+    version: 1.23.2
+    repository: https://grafana.github.io/helm-charts

--- a/charts/tempo/values.yaml
+++ b/charts/tempo/values.yaml
@@ -1,0 +1,2 @@
+tempo:
+  fullnameOverride: tempo

--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -1,0 +1,22 @@
+# Grafana and Tempo Integration
+
+This directory contains dashboards and instructions for connecting Grafana to the Tempo trace backend.
+
+## Install Tempo
+
+Tempo is deployed via the upstream Grafana Helm chart which is referenced in `charts/tempo`.
+
+```sh
+helm repo add grafana https://grafana.github.io/helm-charts
+helm repo update
+# install using the chart in this repository
+helm dependency build charts/tempo
+helm install tempo charts/tempo
+```
+
+The release creates a service named `tempo` that exposes the OTLP gRPC endpoint on port `4317` and the HTTP query endpoint on port `3200`.
+
+## Connect Grafana to Tempo
+
+In Grafana, add a *Tempo* data source with the URL `http://tempo.default.svc.cluster.local:3200`. After saving the data source, traces shipped through the OpenTelemetry Collector become searchable from the **Explore** tab.
+

--- a/k8s/otel-collector.yaml
+++ b/k8s/otel-collector.yaml
@@ -11,18 +11,18 @@ data:
         protocols:
           grpc:
           http:
-    
+
     exporters:
       otlp/tempo:
-        endpoint: tempo:4317
+        endpoint: tempo.default.svc.cluster.local:4317
         tls:
           insecure: true
       prometheus:
         endpoint: "0.0.0.0:8889"
-    
+
     processors:
       batch:
-    
+
     service:
       pipelines:
         traces:

--- a/otel/collector.yaml
+++ b/otel/collector.yaml
@@ -6,7 +6,7 @@ receivers:
 
 exporters:
   otlp/tempo:
-    endpoint: tempo:4317
+    endpoint: tempo.default.svc.cluster.local:4317
     tls:
       insecure: true
   prometheus:


### PR DESCRIPTION
## Summary
- add Tempo deployment chart via Grafana Helm dependency
- point OpenTelemetry Collector to Tempo service
- document Tempo install and Grafana datasource setup

## Testing
- `yamllint charts/tempo/Chart.yaml charts/tempo/values.yaml k8s/otel-collector.yaml otel/collector.yaml`
