### PR TITLE
ci: add Go and policy tests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,6 +22,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Run Go tests
+        working-directory: services/ingest-api
+        run: go test ./...
+
+      - name: Install Conftest
+        run: go install github.com/open-policy-agent/conftest@latest
+        env:
+          GOBIN: /usr/local/bin
+
+      - name: Validate Rego policies
+        run: conftest test policy/
+
       - name: Build and push images
         run: |
           for dir in services/*; do


### PR DESCRIPTION
## Summary
- run Go unit tests for services/ingest-api in CI
- validate Rego policies with conftest in CI
- document Go and policy checks in CI/CD workflow

## Testing
- `go test ./...`
- `conftest test policy/`


------
https://chatgpt.com/codex/tasks/task_e_688f38ac182483299100dc77cedd1800