### PR TITLE
Integrate MLflow tracking and verify model registration

### DIFF
--- a/.github/scripts/check_model_registration.py
+++ b/.github/scripts/check_model_registration.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+import mlflow
+
+
+def main() -> None:
+    tracking_uri = os.getenv("MLFLOW_TRACKING_URI", "http://localhost:5000")
+    model_name = os.getenv("MLFLOW_MODEL_NAME", "flight-model")
+    client = mlflow.MlflowClient(tracking_uri)
+    try:
+        client.get_registered_model(model_name)
+    except Exception as exc:
+        print(f"Model '{model_name}' not registered: {exc}", file=sys.stderr)
+        sys.exit(1)
+    print(f"Model '{model_name}' is registered")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -69,6 +69,20 @@ jobs:
           kubectl get experiment/training-pipeline-random-forest -o jsonpath='{.status.currentOptimalTrial.parameterAssignments}' > katib-best-params.json
           cat katib-best-params.json
 
+      - name: Upload Katib best params
+        uses: actions/upload-artifact@v4
+        with:
+          name: katib-best-params
+          path: katib-best-params.json
+
+      - name: Verify MLflow model registration
+        env:
+          MLFLOW_TRACKING_URI: ${{ secrets.MLFLOW_TRACKING_URI }}
+          MLFLOW_MODEL_NAME: flight-model
+        run: |
+          pip install mlflow
+          python .github/scripts/check_model_registration.py
+
   deploy:
     runs-on: ubuntu-latest
     needs: build

--- a/katib/experiment.yaml
+++ b/katib/experiment.yaml
@@ -38,7 +38,7 @@ spec:
             restartPolicy: Never
             containers:
               - name: training
-                image: ghcr.io/example/training-pipeline:latest
+                image: ghcr.io/example/training-pipeline-mlflow:latest
                 command:
                   - python
                   - /app/training_pipeline.py
@@ -51,3 +51,11 @@ spec:
                     value: /data/data.csv
                   - name: MODEL_OUTPUT
                     value: /output/model.joblib
+                  - name: MLFLOW_TRACKING_URI
+                    value: http://mlflow:5000
+                  - name: MLFLOW_EXPERIMENT_NAME
+                    value: flight-model
+                  - name: MLFLOW_MODEL_NAME
+                    value: flight-model
+                  - name: MODEL_METRIC_THRESHOLD
+                    value: "0.85"

--- a/ml/training_pipeline.py
+++ b/ml/training_pipeline.py
@@ -2,10 +2,16 @@ import os
 from typing import Tuple
 
 import joblib
+import mlflow
 import pandas as pd
 from sklearn.ensemble import RandomForestClassifier
-from sklearn.metrics import accuracy_score
+from sklearn.metrics import accuracy_score, f1_score
 from sklearn.model_selection import train_test_split
+
+
+EXPERIMENT_NAME = os.getenv("MLFLOW_EXPERIMENT_NAME", "flight-model")
+MODEL_NAME = os.getenv("MLFLOW_MODEL_NAME", "flight-model")
+METRIC_THRESHOLD = float(os.getenv("MODEL_METRIC_THRESHOLD", "0.9"))
 
 
 def load_data(path: str) -> Tuple[pd.DataFrame, pd.Series]:
@@ -31,10 +37,12 @@ def train_model(model: RandomForestClassifier, X_train: pd.DataFrame, y_train: p
     return model
 
 
-def evaluate_model(model: RandomForestClassifier, X_test: pd.DataFrame, y_test: pd.Series) -> float:
-    """Evaluate the model and return the accuracy."""
+def evaluate_model(
+    model: RandomForestClassifier, X_test: pd.DataFrame, y_test: pd.Series
+) -> Tuple[float, float]:
+    """Evaluate the model and return accuracy and F1 score."""
     predictions = model.predict(X_test)
-    return accuracy_score(y_test, predictions)
+    return accuracy_score(y_test, predictions), f1_score(y_test, predictions, average="macro")
 
 
 def save_model(model: RandomForestClassifier, output_path: str) -> None:
@@ -47,13 +55,25 @@ def main() -> None:
     model_output = os.getenv("MODEL_OUTPUT", "model.joblib")
 
     X, y = load_data(data_path)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.2, random_state=42
+    )
 
-    model = build_model()
-    model = train_model(model, X_train, y_train)
+    mlflow.set_tracking_uri(os.getenv("MLFLOW_TRACKING_URI", "http://localhost:5000"))
+    mlflow.set_experiment(EXPERIMENT_NAME)
 
-    accuracy = evaluate_model(model, X_test, y_test)
-    print(f"accuracy={accuracy}")
+    with mlflow.start_run() as run:
+        model = build_model()
+        model = train_model(model, X_train, y_train)
+
+        accuracy, f1 = evaluate_model(model, X_test, y_test)
+        print(f"accuracy={accuracy}")
+
+        mlflow.log_params({"n_estimators": model.n_estimators, "max_depth": model.max_depth})
+        mlflow.log_metrics({"accuracy": accuracy, "f1": f1})
+        mlflow.sklearn.log_model(model, "model")
+        if accuracy >= METRIC_THRESHOLD or f1 >= METRIC_THRESHOLD:
+            mlflow.register_model(f"runs:/{run.info.run_id}/model", MODEL_NAME)
 
     save_model(model, model_output)
 


### PR DESCRIPTION
## Summary
- log training parameters and metrics to MLflow
- run Katib trials with an MLflow-enabled image and env configuration
- ensure CI uploads Katib best params and checks MLflow model registration

## Testing
- `python -m py_compile ml/training_pipeline.py`
- `python -m py_compile .github/scripts/check_model_registration.py`
- `PYTHONPATH=$PWD pytest` *(fails: GraphQLRouter.__init__() got an unexpected keyword argument 'dependencies')*
