### PR TITLE
feat: expand global ingress compositions

### DIFF
--- a/infra/crossplane/README.md
+++ b/infra/crossplane/README.md
@@ -6,7 +6,12 @@ label supplied by claims.
 
 ## Installation
 
-Install the composite resource definitions followed by provider-specific compositions:
+Install the composite resource definitions followed by provider-specific compositions. The global ingress now provisions Istio gateways, Cloud Run or App Runner services, and NS1 DNS records so the `provider-kubernetes` and `provider-ns1` providers must be installed:
+
+```bash
+kubectl crossplane install provider crossplane/provider-kubernetes:v0.9.0
+kubectl crossplane install provider crossplane/provider-ns1:v0.3.0
+```
 
 ```bash
 # XRDs
@@ -37,6 +42,6 @@ kubectl apply -f claims/FlightStreamClaim.yaml
 # ClickHouse cluster in a GCP region
 kubectl apply -f claims/CHClusterClaim.yaml
 
-# Global ingress
+# Global ingress with weighted DNS
 kubectl apply -f claims/GlobalIngressClaim.yaml
 ```

--- a/infra/crossplane/claims/GlobalIngressClaim.yaml
+++ b/infra/crossplane/claims/GlobalIngressClaim.yaml
@@ -12,3 +12,6 @@ spec:
   parameters:
     host: ingress.skyroute.io
     region: us-east-1
+    weights:
+      aws: 1
+      gcp: 1

--- a/infra/crossplane/compositions/globalingress-aws.yaml
+++ b/infra/crossplane/compositions/globalingress-aws.yaml
@@ -24,3 +24,62 @@ spec:
           toFieldPath: metadata.labels.host
         - fromFieldPath: spec.parameters.region
           toFieldPath: spec.forProvider.region
+    - name: gateway
+      base:
+        apiVersion: networking.istio.io/v1beta1
+        kind: Gateway
+        metadata:
+          name: global-ingress-gateway
+        spec:
+          selector:
+            istio: ingressgateway
+          servers:
+            - port:
+                number: 80
+                name: http
+                protocol: HTTP
+              hosts:
+                - example.com
+      patches:
+        - fromFieldPath: spec.parameters.host
+          toFieldPath: spec.servers[0].hosts[0]
+        - fromFieldPath: spec.parameters.region
+          toFieldPath: metadata.labels.region
+    - name: apprunner
+      base:
+        apiVersion: apprunner.aws.crossplane.io/v1alpha1
+        kind: Service
+        spec:
+          forProvider:
+            region: us-east-1
+          providerConfigRef:
+            name: aws
+      patches:
+        - fromFieldPath: spec.parameters.host
+          toFieldPath: metadata.labels.host
+        - fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+    - name: ns1record
+      base:
+        apiVersion: dns.ns1.crossplane.io/v1alpha1
+        kind: Record
+        spec:
+          forProvider:
+            zone: skyroute.io
+            domain: ingress.skyroute.io
+            type: CNAME
+            answers:
+              - answer: ingress.skyroute.io
+                meta:
+                  weight: 1
+          providerConfigRef:
+            name: ns1
+      patches:
+        - fromFieldPath: spec.parameters.host
+          toFieldPath: spec.forProvider.domain
+        - fromFieldPath: spec.parameters.host
+          toFieldPath: spec.forProvider.answers[0].answer
+        - fromFieldPath: spec.parameters.region
+          toFieldPath: metadata.labels.region
+        - fromFieldPath: spec.parameters.weights.aws
+          toFieldPath: spec.forProvider.answers[0].meta.weight

--- a/infra/crossplane/compositions/globalingress-gcp.yaml
+++ b/infra/crossplane/compositions/globalingress-gcp.yaml
@@ -24,3 +24,62 @@ spec:
           toFieldPath: metadata.labels.host
         - fromFieldPath: spec.parameters.region
           toFieldPath: spec.forProvider.region
+    - name: gateway
+      base:
+        apiVersion: networking.istio.io/v1beta1
+        kind: Gateway
+        metadata:
+          name: global-ingress-gateway
+        spec:
+          selector:
+            istio: ingressgateway
+          servers:
+            - port:
+                number: 80
+                name: http
+                protocol: HTTP
+              hosts:
+                - example.com
+      patches:
+        - fromFieldPath: spec.parameters.host
+          toFieldPath: spec.servers[0].hosts[0]
+        - fromFieldPath: spec.parameters.region
+          toFieldPath: metadata.labels.region
+    - name: cloudrun
+      base:
+        apiVersion: run.gcp.upbound.io/v1
+        kind: Service
+        spec:
+          forProvider:
+            region: us-central1
+          providerConfigRef:
+            name: gcp
+      patches:
+        - fromFieldPath: spec.parameters.host
+          toFieldPath: metadata.labels.host
+        - fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+    - name: ns1record
+      base:
+        apiVersion: dns.ns1.crossplane.io/v1alpha1
+        kind: Record
+        spec:
+          forProvider:
+            zone: skyroute.io
+            domain: ingress.skyroute.io
+            type: CNAME
+            answers:
+              - answer: ingress.skyroute.io
+                meta:
+                  weight: 1
+          providerConfigRef:
+            name: ns1
+      patches:
+        - fromFieldPath: spec.parameters.host
+          toFieldPath: spec.forProvider.domain
+        - fromFieldPath: spec.parameters.host
+          toFieldPath: spec.forProvider.answers[0].answer
+        - fromFieldPath: spec.parameters.region
+          toFieldPath: metadata.labels.region
+        - fromFieldPath: spec.parameters.weights.gcp
+          toFieldPath: spec.forProvider.answers[0].meta.weight

--- a/infra/crossplane/xrd/CompositeGlobalIngress.yaml
+++ b/infra/crossplane/xrd/CompositeGlobalIngress.yaml
@@ -31,6 +31,20 @@ spec:
                     region:
                       type: string
                       description: Cloud region used to select provider.
+                    weights:
+                      type: object
+                      description: DNS weights for each provider.
+                      properties:
+                        aws:
+                          type: integer
+                          description: Weight for AWS endpoints.
+                        gcp:
+                          type: integer
+                          description: Weight for GCP endpoints.
+                      required:
+                        - aws
+                        - gcp
                   required:
                     - host
                     - region
+                    - weights


### PR DESCRIPTION
## Summary
- add Istio gateways, Cloud Run/App Runner services, and NS1 weighted records to global ingress compositions
- allow GlobalIngress claims to specify DNS weights
- document provider installation for Kubernetes and NS1

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'services')
- `go test ./...` (fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)


------
https://chatgpt.com/codex/tasks/task_e_688f4781991c832996e2485da3d8cf30