### PR TITLE
feat: add ns1 terraform module and integration

### DIFF
--- a/infra/terraform/aws-core/.terraform.lock.hcl
+++ b/infra/terraform/aws-core/.terraform.lock.hcl
@@ -43,3 +43,25 @@ provider "registry.terraform.io/hashicorp/tls" {
     "zh:fb07f708e3316615f6d218cec198504984c0ce7000b9f1eebff7516e384f4b54",
   ]
 }
+
+provider "registry.terraform.io/ns1-terraform/ns1" {
+  version     = "1.13.4"
+  constraints = "~> 1.13"
+  hashes = [
+    "h1:MF63kfPjs0sUtsIRO0GQMO3xrGzo5/TDICy09PSAJV0=",
+    "zh:0dca14dee33312ec077499850a3d684a2d5d0008c43f9277a7e6f03c27db1287",
+    "zh:0f476eae64cb571ba8fa3b05956fbd04caddc271e4342cface97b2b5a0860bf8",
+    "zh:20f41d829a9f1b4720fdb578ac851f90d247c6c84b2606ecefa26cfc09d762b9",
+    "zh:6579f35cb2475b58a7cf754a693e881ae15010f5c8df0886970e9839a2b745c3",
+    "zh:759a167007dde2336b0a07d3f688b357ffc9af7891f38128cbb12e453a20eb2f",
+    "zh:7945a6fdc7b129a810339da6ebfed3d392de25f6c5cabe698f9eb64d9a5cc161",
+    "zh:8ad09cde8a3940438ca356c877bfc1ce59b6821af465a61cad9c4ede32b60639",
+    "zh:8f692a31d260242a5f371db520cfde4383c9990d1ffa20b4f9174eb45889a413",
+    "zh:97806d598ec12103477124a7d56491e3593dfb3f1cffca6c6ec997466a3a4c2b",
+    "zh:97b67438150e9e68657f9935f8fc61e6b0eaeffd50eea0fcdbfeffe122427e3b",
+    "zh:b498f9d5fb0ab6d196018f356ae35a264c91afb052ae9217cbb6f7dc91032a54",
+    "zh:d95310fe6f2163d95b2d32097755aa5a1359a2db5746d75d92ad97cf0b110096",
+    "zh:e5edfa017c728b3008a6091342969548fd3df1f7bf33adda17fa8f680e7ad2ee",
+    "zh:f37856d9f3f4a6ca0502a3e587a0c2cf6a545c3afc5aabacc3a917ff7120733f",
+  ]
+}

--- a/infra/terraform/aws-core/main.tf
+++ b/infra/terraform/aws-core/main.tf
@@ -9,11 +9,19 @@ terraform {
       source  = "hashicorp/tls"
       version = "~> 4.0"
     }
+    ns1 = {
+      source  = "ns1-terraform/ns1"
+      version = "~> 1.13"
+    }
   }
 }
 
 provider "aws" {
   region = var.region
+}
+
+provider "ns1" {
+  apikey = var.ns1_api_key
 }
 
 module "core_network" {
@@ -33,6 +41,15 @@ module "eks_cluster" {
 module "global_dns" {
   source      = "./global-dns"
   environment = var.environment
+}
+
+module "ns1" {
+  source         = "../ns1"
+  zone           = var.ns1_zone
+  record         = var.ns1_record
+  answers        = var.ns1_answers
+  pulsar_app_id  = var.ns1_pulsar_app_id
+  pulsar_type_id = var.ns1_pulsar_type_id
 }
 
 resource "aws_kinesis_stream" "events" {

--- a/infra/terraform/aws-core/outputs.tf
+++ b/infra/terraform/aws-core/outputs.tf
@@ -13,3 +13,13 @@ output "argocd_cluster_endpoint" {
 output "argocd_cluster_ca" {
   value = module.eks_cluster.cluster_ca_certificate
 }
+
+output "ns1_record_id" {
+  description = "ID of the NS1 weighted record"
+  value       = module.ns1.record_id
+}
+
+output "ns1_record_weights" {
+  description = "Map of endpoint weights for the NS1 record"
+  value       = module.ns1.record_weights
+}

--- a/infra/terraform/aws-core/variables.tf
+++ b/infra/terraform/aws-core/variables.tf
@@ -20,3 +20,33 @@ variable "edge_lambda_pubsub_topic" {
   default     = ""
 }
 
+variable "ns1_api_key" {
+  description = "API key for NS1"
+  type        = string
+}
+
+variable "ns1_zone" {
+  description = "DNS zone for NS1 records"
+  type        = string
+}
+
+variable "ns1_record" {
+  description = "Fully qualified domain name of the weighted record"
+  type        = string
+}
+
+variable "ns1_answers" {
+  description = "Map of endpoint IP addresses to their weights"
+  type        = map(number)
+}
+
+variable "ns1_pulsar_app_id" {
+  description = "ID of the NS1 Pulsar application"
+  type        = string
+}
+
+variable "ns1_pulsar_type_id" {
+  description = "Pulsar job type identifier"
+  type        = string
+}
+

--- a/infra/terraform/gcp-core/main.tf
+++ b/infra/terraform/gcp-core/main.tf
@@ -5,12 +5,20 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 5.0"
     }
+    ns1 = {
+      source  = "ns1-terraform/ns1"
+      version = "~> 1.13"
+    }
   }
 }
 
 provider "google" {
   project = var.project_id
   region  = var.region
+}
+
+provider "ns1" {
+  apikey = var.ns1_api_key
 }
 
 module "core_network" {
@@ -33,6 +41,15 @@ module "global_dns" {
   source     = "./modules/global-dns"
   project_id = var.project_id
   domain     = var.domain
+}
+
+module "ns1" {
+  source         = "../ns1"
+  zone           = var.ns1_zone
+  record         = var.ns1_record
+  answers        = var.ns1_answers
+  pulsar_app_id  = var.ns1_pulsar_app_id
+  pulsar_type_id = var.ns1_pulsar_type_id
 }
 
 # Service account for GitHub Actions

--- a/infra/terraform/gcp-core/outputs.tf
+++ b/infra/terraform/gcp-core/outputs.tf
@@ -1,0 +1,9 @@
+output "ns1_record_id" {
+  description = "ID of the NS1 weighted record"
+  value       = module.ns1.record_id
+}
+
+output "ns1_record_weights" {
+  description = "Map of endpoint weights for the NS1 record"
+  value       = module.ns1.record_weights
+}

--- a/infra/terraform/gcp-core/variables.tf
+++ b/infra/terraform/gcp-core/variables.tf
@@ -25,3 +25,33 @@ variable "domain" {
   description = "Base domain for Cloud DNS"
   type        = string
 }
+
+variable "ns1_api_key" {
+  description = "API key for NS1"
+  type        = string
+}
+
+variable "ns1_zone" {
+  description = "DNS zone for NS1 records"
+  type        = string
+}
+
+variable "ns1_record" {
+  description = "Fully qualified domain name of the weighted record"
+  type        = string
+}
+
+variable "ns1_answers" {
+  description = "Map of endpoint IP addresses to their weights"
+  type        = map(number)
+}
+
+variable "ns1_pulsar_app_id" {
+  description = "ID of the NS1 Pulsar application"
+  type        = string
+}
+
+variable "ns1_pulsar_type_id" {
+  description = "Pulsar job type identifier"
+  type        = string
+}

--- a/infra/terraform/ns1/.terraform.lock.hcl
+++ b/infra/terraform/ns1/.terraform.lock.hcl
@@ -1,26 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/google" {
-  version     = "6.46.0"
-  constraints = ">= 5.0.0"
-  hashes = [
-    "h1:Ab1o3RK6fvjnT12Z9KTcDMnStkw+zuzLfjXDAKKtX0A=",
-    "zh:118169da16cb6febf5ec536a3fad2b2749836c7a0d0a4c80dffde8bf3e13530c",
-    "zh:1f70da65e59aff39c28bad2644a2a59b819a0790d4cacc4aa61d75f9682b7e33",
-    "zh:25cff0664b0dfc7851dcf95a785a623516aad12c04ad4e7f1daca380957ddb60",
-    "zh:48f70209b043243e3a3e001db0c205a9c6e8f8e6a73870d29118ef88007b6ae6",
-    "zh:637249a10189a9c7cbbb6819f35b2e1dfc6edf6b2df574cdef9204d98bdd7faa",
-    "zh:6cf1b7e40e92703af6a454ae788b504f1ba466414e1d79d0ceb851c2f9672d69",
-    "zh:976ae598f8247b88d2ce4e4c6b901cd93674538bd5336be51def5c7ffb00872f",
-    "zh:986e9d8e951f51a7225e9b972bf5b80f19557daa35052bc3740f9c0827e0d3d0",
-    "zh:9d8a1c9d0b4c2073db10082c768af92ffef8ab9b1ed2383c041194de8e143c30",
-    "zh:d55a1f71c502f8672225d8a4aaf257191a89fc2232ede63b79d6f237db6b4802",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:fccc1a4dbd98a89c9ce9402aa30418d2afa352286db90d1b1edbbccf48af003b",
-  ]
-}
-
 provider "registry.terraform.io/ns1-terraform/ns1" {
   version     = "1.13.4"
   constraints = "~> 1.13"

--- a/infra/terraform/ns1/main.tf
+++ b/infra/terraform/ns1/main.tf
@@ -1,0 +1,60 @@
+terraform {
+  required_providers {
+    ns1 = {
+      source  = "ns1-terraform/ns1"
+      version = "~> 1.13"
+    }
+  }
+}
+
+resource "ns1_zone" "this" {
+  zone = var.zone
+}
+
+resource "ns1_monitoringjob" "pulsar" {
+  name      = "${var.record}-health"
+  job_type  = "tcp"
+  regions   = ["sjc", "lga", "ams"]
+  frequency = 60
+  config = {
+    host = var.record
+    port = "80"
+  }
+}
+
+resource "ns1_pulsarjob" "this" {
+  name    = "${var.record}-pulsar"
+  app_id  = var.pulsar_app_id
+  type_id = var.pulsar_type_id
+  active  = true
+  config  = {}
+}
+
+resource "ns1_record" "weighted" {
+  zone   = ns1_zone.this.zone
+  domain = var.record
+  type   = "A"
+  ttl    = 60
+
+  dynamic "answers" {
+    for_each = var.answers
+    content {
+      answer = answers.key
+      meta = {
+        weight = tostring(answers.value)
+        up     = "true"
+      }
+    }
+  }
+
+  filters {
+    filter = "weighted_shuffle"
+  }
+
+  filters {
+    filter = "select_first_n"
+    config = {
+      N = "1"
+    }
+  }
+}

--- a/infra/terraform/ns1/outputs.tf
+++ b/infra/terraform/ns1/outputs.tf
@@ -1,0 +1,9 @@
+output "record_id" {
+  description = "ID of the weighted DNS record"
+  value       = ns1_record.weighted.id
+}
+
+output "record_weights" {
+  description = "Map of answer IPs to their weights"
+  value       = { for ans in ns1_record.weighted.answers : ans.answer => tonumber(ans.meta["weight"]) }
+}

--- a/infra/terraform/ns1/variables.tf
+++ b/infra/terraform/ns1/variables.tf
@@ -1,0 +1,24 @@
+variable "zone" {
+  description = "DNS zone name"
+  type        = string
+}
+
+variable "record" {
+  description = "Fully qualified domain name of the weighted record"
+  type        = string
+}
+
+variable "answers" {
+  description = "Map of endpoint IP addresses to their weights"
+  type        = map(number)
+}
+
+variable "pulsar_app_id" {
+  description = "ID of the NS1 Pulsar application"
+  type        = string
+}
+
+variable "pulsar_type_id" {
+  description = "Pulsar job type identifier"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- add reusable ns1 Terraform module with zone, weighted records, and Pulsar health checks
- wire aws-core and gcp-core stacks to ns1 module and expose record outputs

## Testing
- `terraform -chdir=infra/terraform/ns1 init -backend=false`
- `terraform -chdir=infra/terraform/ns1 validate`
- `terraform -chdir=infra/terraform/aws-core init -backend=false`
- `terraform -chdir=infra/terraform/aws-core validate` *(fails: open ../../../services/edge-lambda/handler.zip: no such file or directory)*
- `terraform -chdir=infra/terraform/gcp-core init -backend=false`
- `terraform -chdir=infra/terraform/gcp-core validate`
- `terraform fmt -recursive infra/terraform`


------
https://chatgpt.com/codex/tasks/task_e_688f47827d7c8329bcbc79172f7534a4