### PR TITLE
Add edge caching and NS1 steering

### DIFF
--- a/infra/terraform/aws-core/cloudfront.tf
+++ b/infra/terraform/aws-core/cloudfront.tf
@@ -1,0 +1,34 @@
+resource "aws_cloudfront_distribution" "edge" {
+  enabled             = true
+  default_root_object = "index.html"
+
+  origin {
+    domain_name = var.regional_ingress_dns
+    origin_id   = "regional-ingress"
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
+    target_origin_id = "regional-ingress"
+
+    viewer_protocol_policy = "redirect-to-https"
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}

--- a/infra/terraform/aws-core/outputs.tf
+++ b/infra/terraform/aws-core/outputs.tf
@@ -13,3 +13,7 @@ output "argocd_cluster_endpoint" {
 output "argocd_cluster_ca" {
   value = module.eks_cluster.cluster_ca_certificate
 }
+
+output "cloudfront_domain_name" {
+  value = aws_cloudfront_distribution.edge.domain_name
+}

--- a/infra/terraform/aws-core/variables.tf
+++ b/infra/terraform/aws-core/variables.tf
@@ -20,3 +20,8 @@ variable "edge_lambda_pubsub_topic" {
   default     = ""
 }
 
+
+variable "regional_ingress_dns" {
+  description = "DNS name of the regional ingress load balancer"
+  type        = string
+}

--- a/infra/terraform/gcp-core/cdn.tf
+++ b/infra/terraform/gcp-core/cdn.tf
@@ -1,0 +1,14 @@
+resource "google_compute_backend_service" "cdn" {
+  name        = "${var.project_id}-cdn"
+  protocol    = "HTTP"
+  enable_cdn  = true
+  timeout_sec = 30
+
+  backend {
+    group = var.cdn_backend_group
+  }
+}
+
+resource "google_compute_global_address" "cdn" {
+  name = "${var.project_id}-cdn-ip"
+}

--- a/infra/terraform/gcp-core/outputs.tf
+++ b/infra/terraform/gcp-core/outputs.tf
@@ -1,0 +1,3 @@
+output "cdn_ip" {
+  value = google_compute_global_address.cdn.address
+}

--- a/infra/terraform/gcp-core/variables.tf
+++ b/infra/terraform/gcp-core/variables.tf
@@ -25,3 +25,8 @@ variable "domain" {
   description = "Base domain for Cloud DNS"
   type        = string
 }
+
+variable "cdn_backend_group" {
+  description = "Instance group or NEG backing the Cloud CDN service"
+  type        = string
+}


### PR DESCRIPTION
## Summary
- Add AWS CloudFront distribution for regional ingress
- Add GCP Cloud CDN backend service
- Feed AWS and GCP cache endpoints into NS1 DNS for global traffic steering

## Testing
- `terraform -chdir=infra/terraform/aws-core fmt`
- `terraform -chdir=infra/terraform/aws-core init -backend=false`
- `terraform -chdir=infra/terraform/aws-core validate`
- `terraform -chdir=infra/terraform/gcp-core fmt`
- `terraform -chdir=infra/terraform/gcp-core init -backend=false`
- `terraform -chdir=infra/terraform/gcp-core validate`
- `terraform -chdir=terraform fmt`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`
